### PR TITLE
[Feature][ETL] Restore ETL docker services and connect Etherscan ingestion flow

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -137,6 +137,9 @@ services:
     restart: always
     ports:
       - "442:443"
+    volumes:
+      - /home/mars/chain-analysis/certs/selfsigned.crt:/etc/nginx/certs/selfsigned.crt:ro
+      - /home/mars/chain-analysis/certs/selfsigned.key:/etc/nginx/certs/selfsigned.key:ro
     depends_on:
       backend: { condition: service_healthy }
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,6 +138,7 @@ services:
       - MINIO_SECRET_KEY=minioadmin123
       - MINIO_BUCKET=chain-analysis
       - MINIO_SECURE=false
+      - ETHERSCAN_API_KEY=${ETHERSCAN_API_KEY:-}
     depends_on:
       neo4j:
         condition: service_healthy
@@ -163,21 +164,66 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
-      target: development
+      target: production
     container_name: chain-analysis-frontend
-    environment:
-      - VITE_API_PROXY_TARGET=http://backend:8000
     ports:
-      - "3000:5173"
+      - "3000:80"
     depends_on:
       backend:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:5173/"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1/"]
       interval: 10s
       timeout: 5s
       retries: 3
       start_period: 10s
+    networks:
+      - chain-analysis-net
+
+  # =============================================================================
+  # Rust ETL — Ingest binary (Etherscan → Redis Streams)
+  # Usage: docker compose --profile ingest run --rm ingest --address 0x... --with-traces
+  # =============================================================================
+  ingest:
+    build:
+      context: ./etl-rs
+      dockerfile: Dockerfile
+      target: ingest
+    profiles: [ingest]
+    environment:
+      - ETHERSCAN_API_KEY=${ETHERSCAN_API_KEY:-}
+      - ETHERSCAN_BASE_URL=https://api.etherscan.io/v2/api
+      - ETHERSCAN_CHAIN_ID=1
+      - REDIS_URL=redis://redis:6379
+    depends_on:
+      redis:
+        condition: service_healthy
+    networks:
+      - chain-analysis-net
+
+  # =============================================================================
+  # Rust ETL — Process binary (Redis Streams → Neo4j + PostgreSQL)
+  # Usage: docker compose --profile etl run --rm process --one-shot
+  # =============================================================================
+  process:
+    build:
+      context: ./etl-rs
+      dockerfile: Dockerfile
+      target: process
+    profiles: [etl]
+    environment:
+      - REDIS_URL=redis://redis:6379
+      - NEO4J_URI=bolt://neo4j:7687
+      - NEO4J_USER=neo4j
+      - NEO4J_PASSWORD=password123
+      - DATABASE_URL=postgresql://postgres:postgres123@postgres:5432/chain_analysis
+    depends_on:
+      redis:
+        condition: service_healthy
+      neo4j:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
     networks:
       - chain-analysis-net
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,15 +164,17 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
-      target: production
+      target: development
     container_name: chain-analysis-frontend
+    environment:
+      - VITE_API_PROXY_TARGET=http://backend:8000
     ports:
-      - "3000:80"
+      - "3000:5173"
     depends_on:
       backend:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1/"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:5173/"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -24,14 +24,10 @@ RUN npm run build
 # =============================================================================
 FROM nginx:alpine AS production
 
-<<<<<<< feature/ingest-pipeline
-COPY nginx.production.conf /etc/nginx/conf.d/default.conf
-=======
 # Copy custom nginx config
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 # Copy built assets from builder
->>>>>>> develop
 COPY --from=builder /app/dist /usr/share/nginx/html
 
 EXPOSE 80 443

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -24,23 +24,18 @@ RUN npm run build
 # =============================================================================
 FROM nginx:alpine AS production
 
-# Copy custom nginx config
-COPY nginx.conf /etc/nginx/conf.d/default.conf
-
-# Copy built assets from builder
+COPY nginx.production.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/dist /usr/share/nginx/html
 
-# Expose port
-EXPOSE 80
+EXPOSE 80 443
 
-# Health check
 HEALTHCHECK --interval=10s --timeout=5s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://127.0.0.1/ || exit 1
+    CMD wget --no-verbose --no-check-certificate --tries=1 --spider https://127.0.0.1/ || exit 1
 
 CMD ["nginx", "-g", "daemon off;"]
 
 # =============================================================================
-# Stage 3: Development (alternative target)
+# Stage 3: Development
 # =============================================================================
 FROM node:20-alpine AS development
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -27,19 +27,15 @@ FROM nginx:alpine AS production
 # Copy custom nginx config
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
-# Copy SSL certificates
-COPY certs/selfsigned.crt /etc/nginx/certs/selfsigned.crt
-COPY certs/selfsigned.key /etc/nginx/certs/selfsigned.key
-
 # Copy built assets from builder
 COPY --from=builder /app/dist /usr/share/nginx/html
 
-# Expose ports
-EXPOSE 80 443
+# Expose port
+EXPOSE 80
 
 # Health check
 HEALTHCHECK --interval=10s --timeout=5s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --no-check-certificate --tries=1 --spider https://127.0.0.1/ || exit 1
+    CMD wget --no-verbose --tries=1 --spider http://127.0.0.1/ || exit 1
 
 CMD ["nginx", "-g", "daemon off;"]
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,18 +1,6 @@
-# Redirect HTTP to HTTPS
 server {
     listen 80;
     server_name _;
-    return 301 https://$host$request_uri;
-}
-
-server {
-    listen 443 ssl;
-    server_name _;
-
-    ssl_certificate     /etc/nginx/certs/selfsigned.crt;
-    ssl_certificate_key /etc/nginx/certs/selfsigned.key;
-    ssl_protocols       TLSv1.2 TLSv1.3;
-    ssl_ciphers         HIGH:!aNULL:!MD5;
 
     root /usr/share/nginx/html;
     index index.html;

--- a/frontend/nginx.production.conf
+++ b/frontend/nginx.production.conf
@@ -1,0 +1,48 @@
+# Redirect HTTP to HTTPS
+server {
+    listen 80;
+    server_name _;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name _;
+
+    ssl_certificate     /etc/nginx/certs/selfsigned.crt;
+    ssl_certificate_key /etc/nginx/certs/selfsigned.key;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+    gzip_min_length 1024;
+
+    location /api/ {
+        proxy_pass http://backend:8000/api/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+    }
+
+    location /health {
+        proxy_pass http://backend:8000/health;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+    }
+
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -13,6 +13,8 @@ import type {
     GroupListResponse,
     GroupMemberResponse,
     GroupUpdateRequest,
+    IngestAddressRequest,
+    IngestAddressResponse,
     LoginRequest,
     NeighborsResponse,
     NodeUpsertRequest,
@@ -273,6 +275,15 @@ export async function deleteGroup(address: string): Promise<void> {
 
 export async function fetchGraphStats(): Promise<GraphStatsResponse> {
     return request<GraphStatsResponse>("/stats");
+}
+
+// Pipeline endpoints
+
+export async function ingestAddress(body: IngestAddressRequest): Promise<IngestAddressResponse> {
+    return request<IngestAddressResponse>("/pipeline/ingest-address", {
+        method: "POST",
+        body: JSON.stringify(body),
+    });
 }
 
 // Utility functions

--- a/frontend/src/components/NodePanel.tsx
+++ b/frontend/src/components/NodePanel.tsx
@@ -3,7 +3,7 @@
  */
 import { useState, useEffect } from "react";
 import type { EntityResponse, TransactionResponse } from "../types";
-import { formatAddress, formatWei, fetchGroupMembers, addGroupMember, removeGroupMember } from "../api/client";
+import { formatAddress, formatWei, fetchGroupMembers, addGroupMember, removeGroupMember, ingestAddress } from "../api/client";
 import { useToastContext } from "../context/ToastContext";
 import { RISK_BADGE, ENTITY_LABEL, sectionLabel, labelCls } from "../constants";
 import { CopyButton } from "./CopyButton";
@@ -15,19 +15,21 @@ interface NodePanelProps {
     transactions?: TransactionResponse[];
     onNavigateToAddress?: (address: string) => void;
     overrideMembers?: EntityResponse[];
+    onIngestComplete?: (address: string) => void;
 }
 
 const divider = "border-none border-t border-gray-100 m-0";
 const btnIcon =
     "w-[26px] h-[26px] flex items-center justify-center border border-gray-200 rounded bg-transparent cursor-pointer text-gray-500 p-0 transition-colors hover:bg-gray-100 hover:text-gray-900";
 
-export function NodePanel({ node, onExpand, onClose, transactions, onNavigateToAddress, overrideMembers }: NodePanelProps) {
+export function NodePanel({ node, onExpand, onClose, transactions, onNavigateToAddress, overrideMembers, onIngestComplete }: NodePanelProps) {
     const entityType = node.entity_type || "Unknown";
     const toast = useToastContext();
 
     const [members, setMembers] = useState<EntityResponse[]>([]);
     const [memberInput, setMemberInput] = useState("");
     const [membersLoading, setMembersLoading] = useState(false);
+    const [ingesting, setIngesting] = useState(false);
 
     useEffect(() => {
         let cancelled = false;
@@ -74,6 +76,24 @@ export function NodePanel({ node, onExpand, onClose, transactions, onNavigateToA
             toast.success(`Removed ${formatAddress(childAddress, 4)}`);
         } catch (err: unknown) {
             toast.error(err instanceof Error ? err.message : "Failed to remove member");
+        }
+    };
+
+    const handleIngest = async () => {
+        setIngesting(true);
+        const loadId = toast.loading("Fetching transactions from Etherscan…");
+        try {
+            const result = await ingestAddress({ address: node.address });
+            toast.dismiss(loadId);
+            toast.success(
+                `Ingested ${result.transactions_fetched} txs, ${result.entities_created} entities (${result.duration_seconds.toFixed(1)}s)`,
+            );
+            onIngestComplete?.(node.address);
+        } catch (err: unknown) {
+            toast.dismiss(loadId);
+            toast.error(err instanceof Error ? err.message : "Ingestion failed");
+        } finally {
+            setIngesting(false);
         }
     };
 
@@ -213,6 +233,25 @@ export function NodePanel({ node, onExpand, onClose, transactions, onNavigateToA
                             >
                                 <line x1="5" y1="12" x2="19" y2="12" />
                                 <polyline points="12 5 19 12 12 19" />
+                            </svg>
+                        </button>
+                        <button
+                            className="w-full px-3.5 py-[9px] rounded-lg text-[0.78rem] font-semibold font-[inherit] cursor-pointer flex items-center justify-between transition-colors bg-blue-600 text-white border-none hover:bg-blue-700 disabled:opacity-45 disabled:cursor-not-allowed"
+                            onClick={handleIngest}
+                            disabled={ingesting}
+                        >
+                            {ingesting ? "Fetching…" : "Fetch Transactions"}
+                            <svg
+                                width="12"
+                                height="12"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="2.5"
+                            >
+                                <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
+                                <polyline points="7 10 12 15 17 10" />
+                                <line x1="12" y1="15" x2="12" y2="3" />
                             </svg>
                         </button>
                         <a

--- a/frontend/src/pages/ETLPage.tsx
+++ b/frontend/src/pages/ETLPage.tsx
@@ -14,12 +14,13 @@ import {
     deleteEntity,
     upsertTransaction,
     deleteTransaction,
+    ingestAddress,
     formatAddress,
     formatWei,
     type TransactionUpsertRequest,
 } from "../api/client";
 import { parseTxImportFile, type ParsedTxRow } from "../utils/txImportParser";
-import type { EntityResponse, EntityType, NeighborsResponse, RiskLevel, TransactionResponse } from "../types";
+import type { EntityResponse, EntityType, IngestAddressResponse, NeighborsResponse, RiskLevel, TransactionResponse } from "../types";
 import {
     ENTITY_TYPES,
     RISK_LEVELS,
@@ -99,7 +100,37 @@ export function ETLPage() {
     const importCancelledRef = useRef(false);
     const fileInputRef = useRef<HTMLInputElement>(null);
 
+    // ── Ingest address state ─────────────────────────────────────────────────
+    const [ingestAddr, setIngestAddr] = useState("");
+    const [ingestLoading, setIngestLoading] = useState(false);
+    const [ingestResult, setIngestResult] = useState<IngestAddressResponse | null>(null);
+
     const overallHealthy = health?.status === "healthy";
+
+    const handleIngestAddress = async () => {
+        const addr = ingestAddr.trim().toLowerCase();
+        if (!isValidAddress(addr)) {
+            toast.error("Must be 0x followed by 40 hex characters.");
+            return;
+        }
+        setIngestLoading(true);
+        setIngestResult(null);
+        const id = toast.loading("Fetching from Etherscan…");
+        try {
+            const result = await ingestAddress({ address: addr });
+            setIngestResult(result);
+            toast.dismiss(id);
+            toast.success(
+                `Ingested ${result.transactions_fetched} txs, ${result.entities_created} entities`,
+            );
+            refreshStats();
+        } catch (err) {
+            toast.dismiss(id);
+            toast.error(err instanceof Error ? err.message : "Ingestion failed");
+        } finally {
+            setIngestLoading(false);
+        }
+    };
 
     const handleSearch = async () => {
         const addr = searchAddress.trim().toLowerCase();
@@ -427,6 +458,52 @@ export function ETLPage() {
                         )
                     )}
                 </div>
+
+                {/* Ingest Address from Etherscan */}
+                <Section title="Ingest Address from Etherscan">
+                    <p className="text-[0.75rem] text-gray-500 mb-3">
+                        Fetch all transactions for an address from Etherscan and import entities + transactions into Neo4j and PostgreSQL.
+                    </p>
+                    <div className="flex gap-2">
+                        <input
+                            value={ingestAddr}
+                            onChange={(e) => setIngestAddr(e.target.value)}
+                            onKeyDown={(e) => e.key === "Enter" && handleIngestAddress()}
+                            placeholder="0x… address to ingest"
+                            className={monoCls}
+                        />
+                        <button
+                            onClick={handleIngestAddress}
+                            disabled={ingestLoading || !ingestAddr.trim()}
+                            className={btnPrimary}
+                        >
+                            {ingestLoading ? "Ingesting…" : "Ingest"}
+                        </button>
+                    </div>
+                    {ingestResult && (
+                        <div className="mt-3 p-3 border border-gray-200 rounded-lg bg-green-50">
+                            <p className="text-[0.78rem] font-semibold text-green-700 mb-2">Ingestion Complete</p>
+                            <div className="grid grid-cols-3 gap-3">
+                                {[
+                                    { v: ingestResult.transactions_fetched, l: "Txs Fetched" },
+                                    { v: ingestResult.internal_transactions_fetched, l: "Internal Txs" },
+                                    { v: ingestResult.entities_created, l: "Entities Created" },
+                                    { v: ingestResult.transactions_created, l: "Txs Created" },
+                                    { v: ingestResult.features_computed ? "Yes" : "No", l: "Features" },
+                                    { v: `${ingestResult.duration_seconds.toFixed(1)}s`, l: "Duration" },
+                                ].map(({ v, l }) => (
+                                    <div key={l}>
+                                        <div className="text-[1rem] font-bold text-gray-900 leading-none">{v}</div>
+                                        <div className="text-[0.7rem] text-gray-400 mt-[3px]">{l}</div>
+                                    </div>
+                                ))}
+                            </div>
+                            <p className="font-mono text-[0.68rem] text-gray-500 mt-2">
+                                Run ID: {ingestResult.run_id}
+                            </p>
+                        </div>
+                    )}
+                </Section>
 
                 {/* Lookup */}
                 <Section title="Lookup Entity">

--- a/frontend/src/pages/GraphExplorerPage.tsx
+++ b/frontend/src/pages/GraphExplorerPage.tsx
@@ -7,7 +7,7 @@ import { NodePanel } from "../components/NodePanel";
 import { TxPanel } from "../components/TxPanel";
 import { useToastContext } from "../context/ToastContext";
 import type { EntityResponse, NeighborsResponse, PathResponse, TransactionResponse } from "../types";
-import { fetchEntity, fetchNeighbors, fetchPaths, fetchTransaction } from "../api/client";
+import { fetchEntity, fetchNeighbors, fetchPaths, fetchTransaction, ingestAddress } from "../api/client";
 import { ENTITY_TYPES, RISK_LEVELS, RISK_COLOR } from "../constants";
 import { Background } from "../components/Background";
 
@@ -240,6 +240,24 @@ export function GraphExplorerPage({ initialAddress, initialTxHash, onAddressLoad
             toast.dismiss(loadId);
             toast.error(err instanceof Error ? err.message : "Failed to expand node");
         } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleIngestAndLoad = async (address: string) => {
+        setLoading(true);
+        const loadId = toast.loading("Fetching transactions from Etherscan…");
+        try {
+            const result = await ingestAddress({ address });
+            toast.dismiss(loadId);
+            toast.success(
+                `Ingested ${result.transactions_fetched} txs, ${result.entities_created} entities`,
+            );
+            // Re-search to load the newly ingested data
+            await handleSearch(address);
+        } catch (err) {
+            toast.dismiss(loadId);
+            toast.error(err instanceof Error ? err.message : "Ingestion failed");
             setLoading(false);
         }
     };
@@ -676,6 +694,20 @@ export function GraphExplorerPage({ initialAddress, initialTxHash, onAddressLoad
                                     <span className="w-[5px] h-[5px] rounded-full bg-emerald-500" />
                                     {graphData.total_transactions} transactions
                                 </span>
+                                {graphData.total_transactions === 0 && graphData.center_address && (
+                                    <button
+                                        className="inline-flex items-center gap-[5px] px-3 py-[5px] bg-blue-600 text-white backdrop-blur-sm rounded-full text-[0.7rem] font-semibold border-none cursor-pointer transition-colors hover:bg-blue-700 disabled:opacity-45"
+                                        onClick={() => handleIngestAndLoad(graphData.center_address)}
+                                        disabled={loading}
+                                    >
+                                        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+                                            <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
+                                            <polyline points="7 10 12 15 17 10" />
+                                            <line x1="12" y1="15" x2="12" y2="3" />
+                                        </svg>
+                                        Fetch from Etherscan
+                                    </button>
+                                )}
                             </div>
                         </>
                     ) : (
@@ -740,6 +772,7 @@ export function GraphExplorerPage({ initialAddress, initialTxHash, onAddressLoad
                                 onClose={() => setSelectedNode(null)}
                                 transactions={graphData?.transactions}
                                 onNavigateToAddress={handleNodeSelect}
+                                onIngestComplete={(addr) => handleSearch(addr)}
                                 overrideMembers={
                                     selectedNode.address === "synthetic_high_risk_group" && graphData
                                         ? graphData.nodes.filter(n => n.risk_level === "critical")

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -212,3 +212,20 @@ export interface GraphStatsResponse {
     entity_types: Record<string, number>;
     risk_levels: Record<string, number>;
 }
+
+// Ingestion (pipeline)
+export interface IngestAddressRequest {
+    address: string;
+    chain_id?: number;
+}
+
+export interface IngestAddressResponse {
+    address: string;
+    run_id: string;
+    transactions_fetched: number;
+    internal_transactions_fetched: number;
+    entities_created: number;
+    transactions_created: number;
+    features_computed: boolean;
+    duration_seconds: number;
+}

--- a/scripts/catch_data.sh
+++ b/scripts/catch_data.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Usage: ./catch_data.sh <ethereum_address>
+# Fetches all transactions for the given address from Etherscan,
+# writes them to Redis Streams, then processes into Neo4j + PostgreSQL.
+set -euo pipefail
+
+ADDRESS="${1:-}"
+if [[ -z "$ADDRESS" ]]; then
+  echo "Usage: $0 <ethereum_address>"
+  echo "Example: $0 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+  exit 1
+fi
+
+# Always run docker compose from the repo root where docker-compose.yml lives
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "[1/2] Ingesting $ADDRESS from Etherscan → Redis..."
+docker compose --profile ingest run --rm ingest \
+  --address "$ADDRESS" \
+  --with-traces \
+  --with-transfers
+
+echo "[2/2] Processing Redis → Neo4j + PostgreSQL..."
+docker compose --profile etl run --rm process --one-shot
+
+echo "Done. Data for $ADDRESS is now in the database."


### PR DESCRIPTION
[Overview]
恢復 ETL docker services，重新串接 Etherscan 資料匯入流程，並將資料抓取功能接到前端操作介面，同時提供 CLI script 供一次性資料匯入使用。

[Scope]
1. 恢復 ingest / process docker compose services
2. 修正 frontend container 設定：
- 移除缺失的 SSL certs
- 改用 HTTP nginx
3. 新增 backend 環境變數：
- ETHERSCAN_API_KEY
4. 新增 ingestAddress() API call
5. 在 NodePanel 加入 Fetch Transactions 按鈕
6. 在 ETL 頁面新增 Ingest Address 區塊
7. 新增 scripts/catch_data.sh，支援 CLI one-shot ingestion
8. 不包含：
- 多鏈資料來源整合
- ETL 架構重寫
- 長期排程優化

[Acceptance Criteria]
1. Docker compose 可正常啟動 ETL 相關服務
2. 前端可透過 UI 觸發地址交易抓取
3. Backend 可正常讀取 ETHERSCAN_API_KEY
4. ETL page 可使用 Ingest Address 功能
5. catch_data.sh 可成功執行一次性資料匯入
6. 匯入資料可被前端正常讀取與顯示

[Notes]
1. 後續可加入 cronjob 自動抓取排程
2. 可擴充支援 BSCScan / Arbiscan 等來源
3. 建議補 ingestion error logging 與 retry 機制