### PR TITLE
feature: Add an end-to-end AML detections workflow

### DIFF
--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -14,6 +14,7 @@ from api.deps import close_adapters, init_adapters
 from api.routes import (
     admin_router,
     auth_router,
+    detections_router,
     entities_router,
     entities_write_router,
     features_router,
@@ -89,6 +90,7 @@ def create_app() -> FastAPI:
     app.include_router(groups_router, prefix="/api")
     app.include_router(pipeline_router, prefix="/api")
     app.include_router(ingestion_router, prefix="/api")
+    app.include_router(detections_router, prefix="/api")
 
     return app
 

--- a/backend/src/api/models/__init__.py
+++ b/backend/src/api/models/__init__.py
@@ -2,6 +2,8 @@
 
 from .auth import LoginRequest, RegisterRequest, TokenResponse, UserResponse
 from .entity import (
+    DetectionPattern,
+    DetectionsResponse,
     EntityResponse,
     EntityType,
     NeighborsResponse,
@@ -21,4 +23,6 @@ __all__ = [
     "RiskLevel",
     "NeighborsResponse",
     "PathResponse",
+    "DetectionPattern",
+    "DetectionsResponse",
 ]

--- a/backend/src/api/models/entity.py
+++ b/backend/src/api/models/entity.py
@@ -172,6 +172,37 @@ class PathResponse(BaseModel):
     total_paths: int = Field(..., description="Total number of paths found")
 
 
+class DetectionPattern(str, Enum):
+    """Supported AML detection patterns."""
+
+    PEEL_CHAIN = "peel-chain"
+    STRUCTURING = "structuring"
+    ROUND_TRIP = "round-trip"
+    FAN_OUT_FAN_IN = "fan-out-fan-in"
+    MIXER_INTERACTION = "mixer-interaction"
+
+
+class DetectionsResponse(BaseModel):
+    """Response model for AML detection queries."""
+
+    pattern: DetectionPattern = Field(..., description="AML pattern used")
+    address: str = Field(..., description="Target address")
+    matches: int = Field(..., description="Number of query matches")
+    nodes: list[EntityResponse] = Field(
+        default_factory=list, description="Matched subgraph entity nodes"
+    )
+    transactions: list[TransactionResponse] = Field(
+        default_factory=list, description="Matched subgraph transaction nodes"
+    )
+    highlighted_node_ids: list[str] = Field(
+        default_factory=list, description="Entity addresses to highlight"
+    )
+    highlighted_edge_ids: list[str] = Field(
+        default_factory=list, description="Edge ids (tx-<hash>) to highlight"
+    )
+    truncated: bool = Field(False, description="Whether result set was truncated")
+
+
 class NodeUpsertRequest(BaseModel):
     """Request model for creating or updating a node."""
 

--- a/backend/src/api/routes/__init__.py
+++ b/backend/src/api/routes/__init__.py
@@ -2,6 +2,7 @@
 
 from .admin import router as admin_router
 from .auth import router as auth_router
+from .detections import router as detections_router
 from .entities import (
     router as entities_router,
 )
@@ -22,6 +23,7 @@ from .stats import router as stats_router
 __all__ = [
     "admin_router",
     "auth_router",
+    "detections_router",
     "entities_router",
     "entities_write_router",
     "features_router",

--- a/backend/src/api/routes/detections.py
+++ b/backend/src/api/routes/detections.py
@@ -1,0 +1,220 @@
+"""AML detections API endpoints."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query
+from neo4j.graph import Node as Neo4jNode
+from neo4j.graph import Path as Neo4jPath
+
+from api.deps import GraphDBDep
+from api.models.entity import (
+    DetectionPattern,
+    DetectionsResponse,
+    EntityResponse,
+    RiskLevel,
+    TransactionResponse,
+)
+from graph.queries import AMLPatternQueries
+
+router = APIRouter(prefix="/detections", tags=["detections"])
+
+
+def _validate_address(address: str) -> str:
+    if not address.startswith("0x") or len(address) != 42:
+        raise HTTPException(status_code=400, detail="Invalid address format")
+    return address.lower()
+
+
+def _tx_to_response(tx: dict[str, Any]) -> TransactionResponse:
+    return TransactionResponse(
+        hash=tx.get("hash", ""),
+        from_address=tx.get("from_address", ""),
+        to_address=tx.get("to_address", ""),
+        value=tx.get("value"),
+        block_number=tx.get("block_number"),
+        timestamp=tx.get("timestamp"),
+        gas_used=tx.get("gas_used"),
+        gas_price=tx.get("gas_price"),
+        properties={
+            k: v
+            for k, v in tx.items()
+            if k
+            not in {
+                "hash",
+                "from_address",
+                "to_address",
+                "value",
+                "block_number",
+                "timestamp",
+                "gas_used",
+                "gas_price",
+            }
+        },
+    )
+
+
+def _entity_to_response(node: dict[str, Any]) -> EntityResponse:
+    risk_raw = str(node.get("risk_level", "unknown")).lower()
+    if risk_raw not in {"unknown", "low", "medium", "high", "critical"}:
+        risk_raw = "unknown"
+
+    props = {
+        k: v
+        for k, v in node.items()
+        if k
+        not in {
+            "address",
+            "entity_type",
+            "risk_level",
+            "name",
+            "labels",
+            "first_seen_block",
+            "last_seen_block",
+            "transaction_count",
+            "member_count",
+        }
+    }
+
+    return EntityResponse(
+        address=node.get("address", ""),
+        entity_type=node.get("entity_type"),
+        risk_level=RiskLevel(risk_raw),
+        name=node.get("name"),
+        labels=list(node.get("labels", [])),
+        first_seen_block=node.get("first_seen_block"),
+        last_seen_block=node.get("last_seen_block"),
+        transaction_count=node.get("transaction_count"),
+        member_count=int(node.get("member_count", 0) or 0),
+        properties=props,
+    )
+
+
+def _collect_from_value(
+    value: Any,
+    entities: dict[str, dict[str, Any]],
+    txs: dict[str, dict[str, Any]],
+) -> None:
+    if value is None:
+        return
+
+    if isinstance(value, Neo4jPath):
+        for node in value.nodes:
+            _collect_from_value(node, entities, txs)
+        return
+
+    if isinstance(value, Neo4jNode):
+        labels = set(value.labels)
+        data = dict(value)
+        if "Transaction" in labels:
+            tx_hash = data.get("hash")
+            if tx_hash:
+                txs[tx_hash] = {
+                    "hash": tx_hash,
+                    "from_address": data.get("from_address", ""),
+                    "to_address": data.get("to_address", ""),
+                    "value": data.get("value"),
+                    "block_number": data.get("block_number"),
+                    "timestamp": data.get("timestamp"),
+                    "gas_used": data.get("gas_used"),
+                    "gas_price": data.get("gas_price"),
+                }
+        elif "Entity" in labels or data.get("address"):
+            address = data.get("address")
+            if address:
+                entities[address] = {
+                    "address": address,
+                    "entity_type": data.get("entity_type"),
+                    "risk_level": data.get("risk_level", "unknown"),
+                    "name": data.get("name"),
+                    "labels": [l for l in labels if l != "Entity"],
+                    "first_seen_block": data.get("first_seen_block"),
+                    "last_seen_block": data.get("last_seen_block"),
+                    "transaction_count": data.get("tx_count"),
+                    "member_count": data.get("member_count", 0),
+                }
+        return
+
+    if isinstance(value, dict):
+        if {"hash", "from_address", "to_address"}.issubset(value.keys()):
+            tx_hash = value.get("hash")
+            if tx_hash:
+                txs[tx_hash] = {
+                    "hash": tx_hash,
+                    "from_address": value.get("from_address", ""),
+                    "to_address": value.get("to_address", ""),
+                    "value": value.get("value"),
+                    "block_number": value.get("block") or value.get("block_number"),
+                    "timestamp": value.get("timestamp"),
+                }
+        if "address" in value and isinstance(value["address"], str):
+            entities[value["address"]] = {
+                "address": value["address"],
+                "entity_type": value.get("entity_type"),
+                "risk_level": value.get("risk_level", "unknown"),
+                "name": value.get("name"),
+                "labels": list(value.get("labels", [])),
+                "member_count": value.get("member_count", 0),
+            }
+
+        for nested in value.values():
+            _collect_from_value(nested, entities, txs)
+        return
+
+    if isinstance(value, (list, tuple, set)):
+        for item in value:
+            _collect_from_value(item, entities, txs)
+
+
+@router.get("/{pattern}", response_model=DetectionsResponse)
+async def detect_pattern(
+    pattern: DetectionPattern,
+    address: str,
+    graph_db: GraphDBDep,
+    limit: int = Query(20, ge=1, le=200, description="Maximum matches to return"),
+) -> DetectionsResponse:
+    """Run an AML detection pattern for a target address."""
+    target = _validate_address(address)
+
+    if pattern == DetectionPattern.PEEL_CHAIN:
+        query_result = AMLPatternQueries.detect_peel_chain(target, min_chain_length=3)
+    elif pattern == DetectionPattern.STRUCTURING:
+        query_result = AMLPatternQueries.detect_structuring(target)
+    elif pattern == DetectionPattern.ROUND_TRIP:
+        query_result = AMLPatternQueries.detect_round_trip(target, max_hops=5, limit=limit)
+    elif pattern == DetectionPattern.FAN_OUT_FAN_IN:
+        query_result = AMLPatternQueries.detect_fan_out_fan_in(target)
+    elif pattern == DetectionPattern.MIXER_INTERACTION:
+        query_result = AMLPatternQueries.detect_mixer_interaction(target)
+    else:
+        raise HTTPException(status_code=404, detail="Unknown detection pattern")
+
+    records = await graph_db.execute_query(query_result.query, query_result.params)
+
+    entities: dict[str, dict[str, Any]] = {
+        target: {
+            "address": target,
+            "risk_level": "unknown",
+            "labels": [],
+            "member_count": 0,
+        }
+    }
+    txs: dict[str, dict[str, Any]] = {}
+
+    for record in records:
+        _collect_from_value(record, entities, txs)
+
+    nodes = [_entity_to_response(item) for item in entities.values()]
+    transactions = [_tx_to_response(item) for item in txs.values() if item.get("hash")]
+
+    return DetectionsResponse(
+        pattern=pattern,
+        address=target,
+        matches=len(records),
+        nodes=nodes,
+        transactions=transactions,
+        highlighted_node_ids=[n.address for n in nodes],
+        highlighted_edge_ids=[f"tx-{t.hash}" for t in transactions],
+        truncated=pattern in {DetectionPattern.ROUND_TRIP} and len(records) >= limit,
+    )

--- a/backend/src/graph/queries.py
+++ b/backend/src/graph/queries.py
@@ -234,6 +234,7 @@ class AMLPatternQueries:
               collect(DISTINCT t1) + collect(DISTINCT t2) AS txs
         WHERE size(dsts) >= $min_receivers
         RETURN src.address        AS source,
+               size(mids)         AS intermediaries,
              size(mids)         AS intermediary_count,
              size(dsts)         AS final_receivers,
              [m IN mids | m.address] + [d IN dsts | d.address] AS matched_addresses,

--- a/backend/src/graph/queries.py
+++ b/backend/src/graph/queries.py
@@ -156,13 +156,25 @@ class AMLPatternQueries:
         """
         query = """
         MATCH (src:Entity {address: $address})-[:SENT]->(tx:Transaction)-[:RECEIVED]->(dst:Entity)
-        WITH src, collect(DISTINCT dst) AS receivers, collect(tx.block_number) AS blocks
+                WITH src,
+                         collect(DISTINCT dst) AS receivers,
+                         collect(tx.block_number) AS blocks,
+                         collect(tx) AS txs
         WHERE size(receivers) >= $min_receivers
           AND (max(blocks) - min(blocks)) < $block_window
         RETURN src.address        AS source,
                size(receivers)    AS fan_out,
                min(blocks)        AS first_block,
-               max(blocks)        AS last_block
+                             max(blocks)        AS last_block,
+                             [r IN receivers | r.address] AS matched_addresses,
+                             [t IN txs | {
+                                     hash: t.hash,
+                                     from_address: t.from_address,
+                                     to_address: t.to_address,
+                                     value: t.value,
+                                     block_number: t.block_number,
+                                     timestamp: t.timestamp
+                             }] AS transactions
         ORDER BY fan_out DESC
         """
         return QueryResult(
@@ -216,11 +228,23 @@ class AMLPatternQueries:
         MATCH (src:Entity {address: $address})-[:SENT]->(t1:Transaction)-[:RECEIVED]->(mid:Entity)
         MATCH (mid)-[:SENT]->(t2:Transaction)-[:RECEIVED]->(dst:Entity)
         WHERE src <> dst AND src <> mid AND mid <> dst
-        WITH src, collect(DISTINCT dst) AS dsts, count(DISTINCT mid) AS intermediaries
+         WITH src,
+              collect(DISTINCT dst) AS dsts,
+              collect(DISTINCT mid) AS mids,
+              collect(DISTINCT t1) + collect(DISTINCT t2) AS txs
         WHERE size(dsts) >= $min_receivers
         RETURN src.address        AS source,
-               intermediaries     AS intermediary_count,
-               size(dsts)         AS final_receivers
+             size(mids)         AS intermediary_count,
+             size(dsts)         AS final_receivers,
+             [m IN mids | m.address] + [d IN dsts | d.address] AS matched_addresses,
+             [t IN txs | {
+                 hash: t.hash,
+                 from_address: t.from_address,
+                 to_address: t.to_address,
+                 value: t.value,
+                 block_number: t.block_number,
+                 timestamp: t.timestamp
+             }] AS transactions
         """
         return QueryResult(
             query=query,

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -75,6 +75,20 @@ class TestPipelineEndpoints:
         assert response.status_code == 422
 
 
+class TestDetectionsEndpoints:
+    """Tests for AML detections endpoint registration."""
+
+    def test_detections_route_is_registered(self, client: TestClient):
+        """Endpoint exists and validates required query params."""
+        response = client.get("/api/detections/peel-chain")
+        assert response.status_code == 422
+
+    def test_detections_invalid_address_format(self, client: TestClient):
+        """Invalid address should return 400."""
+        response = client.get("/api/detections/peel-chain?address=invalid")
+        assert response.status_code == 400
+
+
 class TestValidation:
     """Tests for input validation."""
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -3,6 +3,8 @@
  */
 
 import type {
+    DetectionPattern,
+    DetectionsResponse,
     AdminUserCreateRequest,
     AdminUserListResponse,
     AdminUserUpdateRequest,
@@ -173,6 +175,23 @@ export async function fetchPaths(source: string, target: string, options: PathOp
     const endpoint = `/entities/${source}/paths/${target}${query ? `?${query}` : ""}`;
 
     return request<PathResponse>(endpoint);
+}
+
+export interface DetectionOptions {
+    limit?: number;
+}
+
+export async function fetchDetection(
+    pattern: DetectionPattern,
+    address: string,
+    options: DetectionOptions = {},
+): Promise<DetectionsResponse> {
+    const params = new URLSearchParams({ address });
+    if (options.limit !== undefined) {
+        params.set("limit", options.limit.toString());
+    }
+
+    return request<DetectionsResponse>(`/detections/${pattern}?${params.toString()}`);
 }
 
 // Transaction endpoints

--- a/frontend/src/pages/GraphExplorerPage.tsx
+++ b/frontend/src/pages/GraphExplorerPage.tsx
@@ -8,8 +8,15 @@ import { NodePanel } from "../components/NodePanel";
 import { TxPanel } from "../components/TxPanel";
 import { useToastContext } from "../context/ToastContext";
 import { useIngestionRuns } from "../context/IngestionRunsContext";
-import type { EntityResponse, NeighborsResponse, PathResponse, TransactionResponse } from "../types";
-import { fetchEntity, fetchNeighbors, fetchPaths, fetchTransaction, ingestAddress } from "../api/client";
+import type {
+    DetectionPattern,
+    DetectionsResponse,
+    EntityResponse,
+    NeighborsResponse,
+    PathResponse,
+    TransactionResponse,
+} from "../types";
+import { fetchDetection, fetchEntity, fetchNeighbors, fetchPaths, fetchTransaction, ingestAddress } from "../api/client";
 import { ENTITY_TYPES, RISK_LEVELS, RISK_COLOR } from "../constants";
 import { Background } from "../components/Background";
 
@@ -27,6 +34,14 @@ const DEFAULT_FILTERS: GraphFilters = {
 // shared input style used in path-finder and filter panel
 const monoInput =
     "w-60 px-2.5 py-1.5 border border-gray-200 rounded-lg text-[0.75rem] font-mono bg-white text-gray-900 outline-none transition-colors focus:border-blue-400";
+
+const DETECTION_PATTERNS: Array<{ value: DetectionPattern; label: string }> = [
+    { value: "peel-chain", label: "Peel Chain" },
+    { value: "structuring", label: "Structuring" },
+    { value: "round-trip", label: "Round Trip" },
+    { value: "fan-out-fan-in", label: "Fan-Out / Fan-In" },
+    { value: "mixer-interaction", label: "Mixer Interaction" },
+];
 
 export function GraphExplorerPage({ initialAddress, initialTxHash }: GraphExplorerPageProps) {
     const toast = useToastContext();
@@ -50,6 +65,10 @@ export function GraphExplorerPage({ initialAddress, initialTxHash }: GraphExplor
     const [pathTarget, setPathTarget] = useState("");
     const [pathResult, setPathResult] = useState<PathResponse | null>(null);
     const [pathLoading, setPathLoading] = useState(false);
+    const [detectionPattern, setDetectionPattern] = useState<DetectionPattern>("peel-chain");
+    const [detectionAddress, setDetectionAddress] = useState("");
+    const [detectionLoading, setDetectionLoading] = useState(false);
+    const [detectionResult, setDetectionResult] = useState<DetectionsResponse | null>(null);
 
     useEffect(() => {
         if (initialAddress) handleSearch(initialAddress);
@@ -60,6 +79,12 @@ export function GraphExplorerPage({ initialAddress, initialTxHash }: GraphExplor
         if (initialTxHash) handleTxSearch(initialTxHash);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [initialTxHash]);
+
+    useEffect(() => {
+        if (graphData?.center_address && !detectionAddress) {
+            setDetectionAddress(graphData.center_address);
+        }
+    }, [graphData?.center_address, detectionAddress]);
 
     const handleSearch = async (address: string, opts?: { waitForGraph?: boolean }) => {
         // Keep URL in sync so a refresh restores this view.
@@ -505,19 +530,65 @@ export function GraphExplorerPage({ initialAddress, initialTxHash }: GraphExplor
         }
     };
 
+    const handleRunDetection = async () => {
+        const address = detectionAddress.trim() || graphData?.center_address || "";
+        if (!address) {
+            toast.error("Enter an address for detection");
+            return;
+        }
+
+        setDetectionLoading(true);
+        const loadId = toast.loading("Running AML detection…");
+        try {
+            const result = await fetchDetection(detectionPattern, address, { limit: 20 });
+            setDetectionResult(result);
+
+            if (graphData) {
+                const existingAddresses = new Set(graphData.nodes.map((n) => n.address));
+                const existingTxHashes = new Set(graphData.transactions.map((t) => t.hash));
+                const addNodes = result.nodes.filter((n) => !existingAddresses.has(n.address));
+                const addTxs = result.transactions.filter((t) => !existingTxHashes.has(t.hash));
+
+                if (addNodes.length > 0 || addTxs.length > 0) {
+                    setGraphData({
+                        ...graphData,
+                        nodes: [...graphData.nodes, ...addNodes],
+                        transactions: [...graphData.transactions, ...addTxs],
+                        total_nodes: graphData.nodes.length + addNodes.length,
+                        total_transactions: graphData.transactions.length + addTxs.length,
+                    });
+                }
+            }
+
+            toast.dismiss(loadId);
+            toast.success(`Detection finished: ${result.matches} match(es)`);
+        } catch (err) {
+            toast.dismiss(loadId);
+            toast.error(err instanceof Error ? err.message : "Detection failed");
+        } finally {
+            setDetectionLoading(false);
+        }
+    };
+
+    const clearDetection = () => setDetectionResult(null);
+
     const highlightedNodeIds = useMemo(() => {
-        if (!pathResult) return new Set<string>();
         const ids = new Set<string>();
-        pathResult.paths.forEach((p) => p.nodes.forEach((n) => ids.add(n.address)));
+        if (pathResult) {
+            pathResult.paths.forEach((p) => p.nodes.forEach((n) => ids.add(n.address)));
+        }
+        detectionResult?.highlighted_node_ids.forEach((id) => ids.add(id));
         return ids;
-    }, [pathResult]);
+    }, [pathResult, detectionResult]);
 
     const highlightedEdgeIds = useMemo(() => {
-        if (!pathResult) return new Set<string>();
         const ids = new Set<string>();
-        pathResult.paths.forEach((p) => p.transactions.forEach((tx) => ids.add(`tx-${tx.hash}`)));
+        if (pathResult) {
+            pathResult.paths.forEach((p) => p.transactions.forEach((tx) => ids.add(`tx-${tx.hash}`)));
+        }
+        detectionResult?.highlighted_edge_ids.forEach((id) => ids.add(id));
         return ids;
-    }, [pathResult]);
+    }, [pathResult, detectionResult]);
 
     const toggleEntityType = (type: string) => {
         setFilters((prev) => {
@@ -583,6 +654,53 @@ export function GraphExplorerPage({ initialAddress, initialTxHash }: GraphExplor
                         >
                             Clear
                         </button>
+                    )}
+                </div>
+            </div>
+
+            {/* Detections bar */}
+            <div className="shrink-0 border-b border-gray-100 bg-white/80">
+                <div className="flex items-center gap-2.5 px-5 py-2.5">
+                    <span className="text-[0.68rem] font-semibold tracking-widest uppercase text-gray-400">
+                        Detections
+                    </span>
+                    <select
+                        className="px-2.5 py-1.5 border border-gray-200 rounded-lg text-[0.75rem] bg-white text-gray-900"
+                        value={detectionPattern}
+                        onChange={(e) => setDetectionPattern(e.target.value as DetectionPattern)}
+                    >
+                        {DETECTION_PATTERNS.map((p) => (
+                            <option key={p.value} value={p.value}>
+                                {p.label}
+                            </option>
+                        ))}
+                    </select>
+                    <input
+                        className="w-72 px-2.5 py-1.5 border border-gray-200 rounded-lg text-[0.75rem] font-mono bg-white text-gray-900 outline-none transition-colors focus:border-blue-400"
+                        placeholder="Address (0x...)"
+                        value={detectionAddress}
+                        onChange={(e) => setDetectionAddress(e.target.value)}
+                    />
+                    <button
+                        className="px-3.5 py-1.5 bg-gray-900 text-white text-[0.75rem] font-semibold rounded-lg border-none cursor-pointer transition-colors hover:bg-[#1e293b] disabled:opacity-45"
+                        onClick={handleRunDetection}
+                        disabled={detectionLoading}
+                    >
+                        {detectionLoading ? "Running..." : "Run"}
+                    </button>
+                    {detectionResult && (
+                        <button
+                            className="px-3 py-1.5 bg-white text-gray-900 text-[0.75rem] font-medium rounded-lg border border-gray-200 cursor-pointer transition-colors hover:bg-gray-50"
+                            onClick={clearDetection}
+                        >
+                            Clear
+                        </button>
+                    )}
+                    {detectionResult && (
+                        <span className="text-[0.72rem] text-gray-500">
+                            {detectionResult.matches} matches, {detectionResult.highlighted_node_ids.length} nodes, {detectionResult.highlighted_edge_ids.length} txs
+                            {detectionResult.truncated ? " (truncated)" : ""}
+                        </span>
                     )}
                 </div>
             </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -132,6 +132,24 @@ export interface PathData {
     total_value?: string | null;
 }
 
+export type DetectionPattern =
+    | "peel-chain"
+    | "structuring"
+    | "round-trip"
+    | "fan-out-fan-in"
+    | "mixer-interaction";
+
+export interface DetectionsResponse {
+    pattern: DetectionPattern;
+    address: string;
+    matches: number;
+    nodes: EntityResponse[];
+    transactions: TransactionResponse[];
+    highlighted_node_ids: string[];
+    highlighted_edge_ids: string[];
+    truncated: boolean;
+}
+
 export interface HealthResponse {
     status: "healthy" | "degraded";
     services: Record<string, boolean>;


### PR DESCRIPTION
This PR introduces a new **Detections API** along with frontend integration in the Graph Explorer for AML pattern analysis and visualization.

---

##  Backend Changes

### 1. Detections API

* Added new endpoint:

  ```
  GET /api/detections/{pattern}?address=...&limit=...
  ```
* Implemented in `detections.py`

### 2. Typed Models

* Added detection-related models:

  * `DetectionPattern` enum
  * `DetectionsResponse` payload

    * Includes nodes, transactions, and highlight IDs
* Implemented in `entity.py`
* Exported via `__init__.py`

### 3. Router Registration

* Registered detections router in:

  * `__init__.py`
  * `main.py`

### 4. AML Query Enhancements

* Extended query builders for better UI support:

  * Structuring
  * Fan-out / Fan-in
* Now returns:

  * Matched addresses
  * Transaction payloads
* Implemented in `queries.py`

---

##  Frontend Changes

### 1. API Integration

* Added detection-related types in `index.ts`
* Implemented API client helper:

  * `fetchDetection(...)` in `client.ts`

### 2. Graph Explorer UI

* Added minimal Detections interface in `GraphExplorerPage.tsx`:

  * Pattern selector
  * Address input
  * Run / Clear controls
* Behavior:

  * Merges returned subgraph into current canvas
  * Highlights matched nodes and edges using existing mechanism

---

##  Tests

* Added API tests in `test_api.py`:

  * Route registration
  * Invalid address validation

---

##  Compatibility / CI

* Maintained backward compatibility for fan-out / fan-in query outputs:

  * Preserved legacy intermediary fields
  * Added new fields (e.g. `intermediary_count`)
* Ensures existing query-string assertions in tests are not broken

