### PR TITLE
feat(api): add backend typing

### DIFF
--- a/backend/src/api/routes/admin.py
+++ b/backend/src/api/routes/admin.py
@@ -164,7 +164,11 @@ async def update_user(
     return response
 
 
-@router.delete("/users/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/users/{user_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_model=None,
+)
 async def delete_user(
     user_id: int,
     db: RelationalDBDep,

--- a/backend/src/api/routes/entities.py
+++ b/backend/src/api/routes/entities.py
@@ -342,7 +342,7 @@ async def update_entity(
     )
 
 
-@write_router.delete("/{address}", status_code=204)
+@write_router.delete("/{address}", status_code=204, response_model=None)
 async def delete_entity(
     address: str,
     graph_db: GraphDBDep,
@@ -449,7 +449,11 @@ async def add_group_member(
     )
 
 
-@write_router.delete("/{address}/members/{member_address}", status_code=204)
+@write_router.delete(
+    "/{address}/members/{member_address}",
+    status_code=204,
+    response_model=None,
+)
 async def remove_group_member(
     address: str,
     member_address: str,
@@ -541,7 +545,7 @@ async def upsert_transaction(
     )
 
 
-@transactions_router.delete("/{hash}", status_code=204)
+@transactions_router.delete("/{hash}", status_code=204, response_model=None)
 async def delete_transaction(
     hash: str,
     graph_db: GraphDBDep,

--- a/backend/src/api/routes/groups.py
+++ b/backend/src/api/routes/groups.py
@@ -157,7 +157,7 @@ async def update_group(
     return _build_group_detail(refreshed, members)
 
 
-@router.delete("/{address}", status_code=204)
+@router.delete("/{address}", status_code=204, response_model=None)
 async def delete_group(address: str, graph_db: GraphDBDep) -> None:
     """Delete a group entity. Fails with 409 if the group still has members."""
     address = _validate_address(address)

--- a/backend/src/api/routes/health.py
+++ b/backend/src/api/routes/health.py
@@ -22,6 +22,12 @@ class ServiceStatus(BaseModel):
     message: str | None = None
 
 
+class HealthStatusResponse(BaseModel):
+    """Simple health status response for probes."""
+
+    status: str
+
+
 @router.get("/health", response_model=HealthResponse)
 async def health_check(
     graph_db: GraphDBDep,
@@ -63,21 +69,21 @@ async def health_check(
     return HealthResponse(status=status, services=services)
 
 
-@router.get("/health/live")
-async def liveness_probe() -> dict[str, str]:
+@router.get("/health/live", response_model=HealthStatusResponse)
+async def liveness_probe() -> HealthStatusResponse:
     """
     Kubernetes liveness probe.
 
     Simply returns OK to indicate the service is running.
     """
-    return {"status": "ok"}
+    return HealthStatusResponse(status="ok")
 
 
-@router.get("/health/ready")
+@router.get("/health/ready", response_model=HealthStatusResponse)
 async def readiness_probe(
     graph_db: GraphDBDep,
     relational_db: RelationalDBDep,
-) -> dict[str, str]:
+) -> HealthStatusResponse:
     """
     Kubernetes readiness probe.
 
@@ -97,4 +103,4 @@ async def readiness_probe(
     except Exception as e:
         raise HTTPException(status_code=503, detail=f"PostgreSQL error: {e}")
 
-    return {"status": "ready"}
+    return HealthStatusResponse(status="ready")

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,6 +1,7 @@
 """Tests for API endpoints."""
 
 from fastapi.testclient import TestClient
+from fastapi.routing import APIRoute
 
 
 class TestHealthEndpoints:
@@ -98,3 +99,29 @@ class TestValidation:
             },
         )
         assert response.status_code == 422
+
+
+class TestRouteResponseModels:
+    """Ensure API routes declare explicit response models."""
+
+    def test_api_routes_have_response_models_or_no_content(self, client: TestClient):
+        routes = [
+            route
+            for route in client.app.routes
+            if isinstance(route, APIRoute)
+            and route.path.startswith(("/api", "/health"))
+        ]
+
+        assert routes, "Expected API routes to inspect"
+
+        missing = []
+        for route in routes:
+            if route.status_code == 204:
+                if route.response_model is not None:
+                    missing.append(f"{route.path} should not declare a response model")
+                continue
+
+            if route.response_model is None:
+                missing.append(f"{route.path} is missing response_model")
+
+        assert not missing, "\n".join(missing)


### PR DESCRIPTION
This PR standardizes API response contracts by enforcing explicit `response_model` usage on all backend routes.

- Added explicit response models for health probe endpoints `health/live`,  `health/ready`.
- Marked all 204 delete endpoints with `response_model=None` to make no-content behavior explicit.
- Added a regression test to verify routes under `/api` and `/health` always declare a response model (or explicit no-content for 204).