### PR TITLE
feat: API Rate Limiting

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -19,6 +19,8 @@ dependencies = [
 
     # Message Queue
     "redis>=5.2.0",
+    "slowapi>=0.1.4",
+    "limits>=2.9.0",
 
     # ETL Orchestration
     "dagster>=1.9.0",

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -9,6 +9,9 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from slowapi.middleware import SlowAPIMiddleware
+from slowapi.errors import RateLimitExceeded
+from slowapi import _rate_limit_exceeded_handler
 
 from api.deps import close_adapters, init_adapters
 from api.routes import (
@@ -28,6 +31,7 @@ from api.routes import (
 )
 from core.config import get_settings
 from libs import logger
+from libs.rate_limiter import limiter
 
 
 @asynccontextmanager
@@ -65,6 +69,11 @@ def create_app() -> FastAPI:
         docs_url="/docs",
         redoc_url="/redoc",
     )
+
+    # Attach limiter to app state and register middleware / handler
+    app.state.limiter = limiter
+    app.add_middleware(SlowAPIMiddleware)
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
     # CORS middleware
     app.add_middleware(

--- a/backend/src/api/routes/labels.py
+++ b/backend/src/api/routes/labels.py
@@ -8,6 +8,8 @@ from pydantic import BaseModel, Field
 from sqlalchemy import select, text
 
 from api.deps import MessageQueueDep, RelationalDBDep, SettingsDep
+from libs.rate_limiter import limiter
+from core.config import get_settings
 from api.models.entity import (
     AnnotationCreate,
     AnnotationResponse,
@@ -124,6 +126,7 @@ async def enqueue_label_fetch(
 
 
 @router.post("/tasks", response_model=LabelTaskResponse, status_code=201)
+@limiter.limit(get_settings().rate_limit_labels)
 async def create_label_task(
     task: LabelTaskCreate,
     db: RelationalDBDep,

--- a/backend/src/api/routes/labels.py
+++ b/backend/src/api/routes/labels.py
@@ -3,7 +3,7 @@
 import json
 from typing import Literal
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 from sqlalchemy import select, text
 
@@ -128,6 +128,7 @@ async def enqueue_label_fetch(
 @router.post("/tasks", response_model=LabelTaskResponse, status_code=201)
 @limiter.limit(get_settings().rate_limit_labels)
 async def create_label_task(
+    request: Request,
     task: LabelTaskCreate,
     db: RelationalDBDep,
 ) -> LabelTaskResponse:

--- a/backend/src/api/routes/pipeline.py
+++ b/backend/src/api/routes/pipeline.py
@@ -17,6 +17,8 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from api.deps import MessageQueueDep, RelationalDBDep, SettingsDep
+from libs.rate_limiter import limiter
+from core.config import get_settings
 
 router = APIRouter(prefix="/pipeline", tags=["pipeline"])
 
@@ -40,6 +42,7 @@ def _validate_address(address: str) -> str:
 
 
 @router.post("/ingest-address", response_model=IngestAddressResponse, status_code=202)
+@limiter.limit(get_settings().rate_limit_ingest)
 async def ingest_address(
     body: IngestAddressRequest,
     settings: SettingsDep,

--- a/backend/src/api/routes/pipeline.py
+++ b/backend/src/api/routes/pipeline.py
@@ -13,7 +13,7 @@ Clients poll `GET /api/ingestion-runs/{run_id}` to observe progress.
 import json
 from uuid import uuid4
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
 from api.deps import MessageQueueDep, RelationalDBDep, SettingsDep
@@ -44,6 +44,7 @@ def _validate_address(address: str) -> str:
 @router.post("/ingest-address", response_model=IngestAddressResponse, status_code=202)
 @limiter.limit(get_settings().rate_limit_ingest)
 async def ingest_address(
+    request: Request,
     body: IngestAddressRequest,
     settings: SettingsDep,
     db: RelationalDBDep,

--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -110,6 +110,10 @@ class Settings(BaseSettings):
         default=["http://localhost:3000", "http://localhost:5173"]
     )
 
+    # Rate limiting (slowapi style strings, e.g. "5/minute", "100/hour")
+    rate_limit_ingest: str = "5/minute"
+    rate_limit_labels: str = "30/minute"
+
     # =========================================================================
     # Dagster
     # =========================================================================

--- a/backend/src/libs/rate_limiter.py
+++ b/backend/src/libs/rate_limiter.py
@@ -1,0 +1,41 @@
+"""Rate limiter initialization using slowapi + Redis storage.
+
+Keying strategy: if a valid JWT Bearer token is present, use `user:{sub}`
+otherwise fall back to remote IP address.
+"""
+from fastapi import Request
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+from core.config import get_settings
+from services.auth import decode_access_token
+
+
+def _key_func(request: Request) -> str:
+    """Return a key for rate limiting based on user id (sub) or IP.
+
+    This function is intentionally defensive: any failure to decode the JWT
+    falls back to IP-based limiting.
+    """
+    auth = request.headers.get("Authorization", "")
+    if auth.startswith("Bearer "):
+        token = auth.split(" ", 1)[1]
+        try:
+            settings = get_settings()
+            payload = decode_access_token(token, settings.jwt_secret_key, settings.jwt_algorithm)
+            user_id = payload.get("sub")
+            if user_id:
+                return f"user:{user_id}"
+        except Exception:
+            # any failure -> fall back to IP
+            pass
+
+    return get_remote_address(request)
+
+
+settings = get_settings()
+
+# Initialize limiter with Redis storage URI from settings
+limiter = Limiter(key_func=_key_func, storage_uri=settings.redis_url)
+
+__all__ = ["limiter"]

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -1,0 +1,67 @@
+import sys
+import asyncio
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from slowapi import Limiter
+from slowapi.middleware import SlowAPIMiddleware
+from slowapi.errors import RateLimitExceeded
+from slowapi import _rate_limit_exceeded_handler
+
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_ingest_rate_limit_memory_storage():
+    """Minimal end-to-end test of rate limiting using in-memory storage.
+
+    This test creates a tiny FastAPI app with SlowAPI middleware and a
+    single endpoint decorated with a small limit. We avoid the project
+    app lifecycle and adapters to keep the test hermetic.
+    """
+    # Use memory storage to avoid requiring a running Redis instance
+    limiter = Limiter(key_func=lambda request: request.client.host, storage_uri="memory://")
+
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_middleware(SlowAPIMiddleware)
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+    @app.post("/test-ingest")
+    @limiter.limit("2/minute")
+    async def _test_ingest(request: Request):
+        return JSONResponse({"ok": True}, status_code=202)
+
+    async with AsyncClient(app=app, base_url="http://test") as client:
+        r1 = await client.post("/test-ingest")
+        assert r1.status_code == 202
+
+        r2 = await client.post("/test-ingest")
+        assert r2.status_code == 202
+
+        # Third request should be rate-limited
+        r3 = await client.post("/test-ingest")
+        assert r3.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_labels_rate_limit_memory_storage():
+    """Same as above but for a different endpoint and limit."""
+    limiter = Limiter(key_func=lambda request: request.client.host, storage_uri="memory://")
+
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_middleware(SlowAPIMiddleware)
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+    @app.post("/test-labels")
+    @limiter.limit("1/minute")
+    async def _test_labels(request: Request):
+        return JSONResponse({"ok": True}, status_code=201)
+
+    async with AsyncClient(app=app, base_url="http://test") as client:
+        r1 = await client.post("/test-labels")
+        assert r1.status_code == 201
+        r2 = await client.post("/test-labels")
+        assert r2.status_code == 429

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -9,7 +9,7 @@ from slowapi.middleware import SlowAPIMiddleware
 from slowapi.errors import RateLimitExceeded
 from slowapi import _rate_limit_exceeded_handler
 
-from httpx import AsyncClient
+from httpx import AsyncClient, ASGITransport
 
 
 @pytest.mark.asyncio
@@ -33,7 +33,8 @@ async def test_ingest_rate_limit_memory_storage():
     async def _test_ingest(request: Request):
         return JSONResponse({"ok": True}, status_code=202)
 
-    async with AsyncClient(app=app, base_url="http://test") as client:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
         r1 = await client.post("/test-ingest")
         assert r1.status_code == 202
 
@@ -60,7 +61,8 @@ async def test_labels_rate_limit_memory_storage():
     async def _test_labels(request: Request):
         return JSONResponse({"ok": True}, status_code=201)
 
-    async with AsyncClient(app=app, base_url="http://test") as client:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
         r1 = await client.post("/test-labels")
         assert r1.status_code == 201
         r2 = await client.post("/test-labels")


### PR DESCRIPTION
This PR implements per-user rate limiting for two critical endpoints that are vulnerable to abuse:
- `POST /api/pipeline/ingest-address` — triggers expensive Etherscan API queries
- `POST /api/labels/tasks` — creates high-volume label ingestion tasks

### Solution
Implemented rate limiting using **slowapi** (based on the `limits` library) with **Redis** as the storage backend, using JWT-aware per-user keying.

### Key Features
- **Per-user limiting**: Rate limit keys use JWT `sub` (user ID) when available, falling back to client IP
- **Configurable limits**: 
  - `rate_limit_ingest`: 5 requests/minute (default)
  - `rate_limit_labels`: 30 requests/minute (default)
- **Redis-backed**: Shared rate limit state across multiple worker replicas
- **Standard HTTP responses**: Exceeding limits returns 429 Too Many Requests

### Configuration
Rate limits can be overridden via environment variables in `.env` or `docker-compose.yml` (default value is in `config.py`):
```env
RATE_LIMIT_INGEST=5/minute
RATE_LIMIT_LABELS=30/minute
```