### PR TITLE
feat: E2E test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,157 @@ jobs:
       - name: Build production image
         run: docker build -f backend/Dockerfile -t chain-analysis-backend:ci .
 
+  rust-etl:
+    name: Rust ETL validation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: etl-rs -> target
+
+      - name: Test
+        working-directory: etl-rs
+        run: cargo test --workspace
+
+  e2e:
+    name: E2E smoke journey
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Prepare local compose secrets
+        run: |
+          set -euo pipefail
+          mkdir -p compose
+
+          cat > .env <<'EOF'
+          ENVIRONMENT=local
+          NEO4J_URI=bolt://localhost:7687
+          NEO4J_USER=neo4j
+          NEO4J_PASSWORD=changeme
+          NEO4J_AUTH=neo4j/changeme
+          NEO4J_PLUGINS=[]
+          POSTGRES_HOST=localhost
+          POSTGRES_PORT=5432
+          POSTGRES_DB=chain_analysis
+          POSTGRES_USER=postgres
+          POSTGRES_PASSWORD=changeme
+          REDIS_PASSWORD=changeme
+          REDIS_URL=redis://localhost:6379
+          DATABASE_URL=postgresql://postgres:changeme@localhost:5432/chain_analysis
+          CLICKHOUSE_DB=chain_analysis
+          CLICKHOUSE_USER=default
+          CLICKHOUSE_PASSWORD=changeme
+          JWT_SECRET_KEY=changeme
+          ETHERSCAN_API_KEY=
+          ALCHEMY_API_KEY=
+          INGEST_SOURCE=
+          EOF
+
+          cat > compose/secrets.dev.env <<'EOF'
+          ENVIRONMENT=local
+          NEO4J_URI=bolt://neo4j:7687
+          NEO4J_USER=neo4j
+          NEO4J_PASSWORD=changeme
+          NEO4J_AUTH=neo4j/changeme
+          NEO4J_PLUGINS=[]
+          POSTGRES_HOST=postgres
+          POSTGRES_PORT=5432
+          POSTGRES_DB=chain_analysis
+          POSTGRES_USER=postgres
+          POSTGRES_PASSWORD=changeme
+          REDIS_PASSWORD=changeme
+          REDIS_URL=redis://redis:6379
+          DATABASE_URL=postgresql://postgres:changeme@postgres:5432/chain_analysis
+          CLICKHOUSE_DB=chain_analysis
+          CLICKHOUSE_USER=default
+          CLICKHOUSE_PASSWORD=changeme
+          JWT_SECRET_KEY=changeme
+          ETHERSCAN_API_KEY=
+          ALCHEMY_API_KEY=
+          INGEST_SOURCE=
+          EOF
+
+      - name: Start E2E stack
+        run: |
+          set -euo pipefail
+
+          docker compose up -d neo4j postgres redis backend frontend
+
+          deadline=$((SECONDS + 360))
+          while true; do
+            backend_state="$(docker inspect -f '{{.State.Status}} {{if .State.Health}}{{.State.Health.Status}}{{end}}' chain-analysis-backend 2>/dev/null || true)"
+            frontend_state="$(docker inspect -f '{{.State.Status}} {{if .State.Health}}{{.State.Health.Status}}{{end}}' chain-analysis-frontend 2>/dev/null || true)"
+            echo "backend=${backend_state:-missing} frontend=${frontend_state:-missing}"
+
+            if echo "$backend_state $frontend_state" | grep -q 'exited'; then
+              docker compose ps
+              docker compose logs --no-color --tail=200 backend frontend
+              exit 1
+            fi
+
+            if echo "$backend_state" | grep -q 'healthy' && echo "$frontend_state" | grep -q 'healthy'; then
+              break
+            fi
+
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              docker compose ps
+              docker compose logs --no-color --tail=200 backend frontend
+              exit 1
+            fi
+
+            sleep 5
+          done
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Install Playwright runner
+        working-directory: frontend
+        run: |
+          npm install --no-save @playwright/test
+          npx playwright install --with-deps chromium
+
+      - name: Run E2E smoke journey
+        working-directory: frontend
+        env:
+          PLAYWRIGHT_BASE_URL: http://127.0.0.1:5173
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report
+          if-no-files-found: ignore
+
+      - name: Stop E2E stack
+        if: always()
+        run: docker compose down -v
+
+      - name: Remove local compose secrets
+        if: always()
+        run: rm -f .env compose/secrets.dev.env
+
   compose:
     name: Compose validation
     runs-on: ubuntu-latest

--- a/backend/src/api/routes/labels.py
+++ b/backend/src/api/routes/labels.py
@@ -326,7 +326,7 @@ async def create_annotation(
         )
         VALUES (
             :task_id, NULL, :address, :entity_type,
-            :risk_level, :labels, :notes, :evidence, :confidence
+            :risk_level, CAST(:labels AS JSON), :notes, CAST(:evidence AS JSON), :confidence
         )
         RETURNING id, task_id, user_id, entity_address, entity_type,
                   risk_level, labels, notes, confidence, created_at
@@ -338,9 +338,9 @@ async def create_annotation(
                 annotation.entity_type.value if annotation.entity_type else None
             ),
             "risk_level": annotation.risk_level.value,
-            "labels": annotation.labels,
+            "labels": json.dumps(annotation.labels) if annotation.labels is not None else None,
             "notes": annotation.notes,
-            "evidence": annotation.evidence,
+            "evidence": json.dumps(annotation.evidence) if annotation.evidence is not None else None,
             "confidence": annotation.confidence,
         },
     )

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -44,7 +44,12 @@ test("analyst smoke journey: login, ingest, explore, queue label, annotate", asy
   await page.getByTestId("annotation-labels").fill("smoke-test");
   await page.getByTestId("annotation-notes").fill("Smoke journey annotation");
   await page.getByTestId("annotation-confidence").fill("0.8");
+  const annotationResponsePromise = page.waitForResponse((response) =>
+    response.url().includes("/api/labels/annotations") && response.request().method() === "POST",
+  );
   await page.getByTestId("annotation-submit").click();
+  const annotationResponse = await annotationResponsePromise;
+  expect(annotationResponse.ok()).toBeTruthy();
 
   await expect(page.getByText("Annotation submitted")).toBeVisible();
 });

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+
+const explorerAddress = "0x28c6c06298d514db089934071355e5743bf21d60";
+
+function uniqueAddress(): string {
+  const suffix = Date.now().toString(16).padStart(40, "0").slice(-40);
+  return `0x${suffix}`;
+}
+
+test("analyst smoke journey: login, ingest, explore, queue label, annotate", async ({ page }) => {
+  const queuedAddress = uniqueAddress();
+
+  await page.goto("/login");
+  await page.getByTestId("login-email").fill("operator@example.com");
+  await page.getByTestId("login-password").fill("Operator@chain2024!");
+  await page.getByTestId("login-submit").click();
+
+  await expect(page).toHaveURL(/\/explorer/);
+  await expect(page.getByTestId("nav-tab-explorer")).toBeVisible();
+
+  await page.getByTestId("address-search").fill(queuedAddress);
+  await page.getByTestId("address-search-submit").click();
+  await expect(page.getByTestId("graph-stats-transactions")).toContainText("0 transactions");
+  await page.getByTestId("fetch-address").click();
+  await expect(page.getByText(/Queued ingest/)).toBeVisible();
+
+  await page.getByTestId("address-search").fill(explorerAddress);
+  await page.getByTestId("address-search-submit").click();
+  await expect(page.getByTestId("graph-stats-entities")).toContainText(/entities/);
+  await expect(page.getByTestId("graph-stats-transactions")).toContainText(/transactions/);
+
+  await page.getByTestId("nav-tab-labels").click();
+  await expect(page).toHaveURL(/\/labels/);
+  await page.getByTestId("label-addresses-input").fill(queuedAddress);
+  await page.getByTestId("label-queue-submit").click();
+  await expect(page.getByText(/Queued 1 task/)).toBeVisible();
+
+  const row = page.locator(`[data-testid="label-task-row"][data-entity-address="${queuedAddress}"]`);
+  await expect(row).toBeVisible();
+  await row.getByTestId("label-annotate-button").click();
+
+  await page.getByTestId("annotation-entity-type").selectOption("EOA");
+  await page.getByTestId("annotation-risk-medium").click();
+  await page.getByTestId("annotation-labels").fill("smoke-test");
+  await page.getByTestId("annotation-notes").fill("Smoke journey annotation");
+  await page.getByTestId("annotation-confidence").fill("0.8");
+  await page.getByTestId("annotation-submit").click();
+
+  await expect(page.getByText("Annotation submitted")).toBeVisible();
+});

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -20,7 +20,7 @@ const browserGlobals = {
 
 export default [
   {
-    ignores: ["**/dist/**", "**/node_modules/**"],
+    ignores: ["**/dist/**", "**/node_modules/**", "e2e/**", "playwright.config.ts"],
   },
   {
     linterOptions: {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --max-warnings 0",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "clsx": "^2.1.1",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 60_000,
+  expect: {
+    timeout: 15_000,
+  },
+  fullyParallel: true,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:5173",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -111,6 +111,7 @@ export function Nav() {
                             <NavLink
                                 key={tab.to}
                                 to={tab.to}
+                                data-testid={`nav-tab-${tab.label.toLowerCase()}`}
                                 className={({ isActive }) =>
                                     "flex items-center gap-1.5 px-3.5 py-1.5 rounded-full text-[0.8rem] font-medium transition-all whitespace-nowrap no-underline " +
                                     (isActive

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -79,6 +79,7 @@ export function SearchBar({ onSearch, onSearchTx, loading }: SearchBarProps) {
 
                     <input
                         id="address-search"
+                        data-testid="address-search"
                         type="text"
                         value={value}
                         onChange={(e) => {
@@ -102,6 +103,7 @@ export function SearchBar({ onSearch, onSearchTx, loading }: SearchBarProps) {
 
             <button
                 type="submit"
+                data-testid="address-search-submit"
                 disabled={loading || !value.trim()}
                 className="flex-shrink-0 inline-flex items-center justify-center gap-1.5 px-4 py-2 bg-gray-900 text-white text-[0.8rem] font-semibold rounded-lg shadow-sm transition-all hover:-translate-y-px hover:shadow-md disabled:opacity-45 disabled:cursor-not-allowed disabled:translate-y-0"
             >

--- a/frontend/src/pages/GraphExplorerPage.tsx
+++ b/frontend/src/pages/GraphExplorerPage.tsx
@@ -1022,11 +1022,17 @@ export function GraphExplorerPage({ initialAddress, initialTxHash }: GraphExplor
 
                             {/* Stats bar */}
                             <div className="absolute bottom-5 left-5 z-10 flex gap-2">
-                                <span className="inline-flex items-center gap-[5px] px-2.5 py-[5px] bg-[rgba(249,250,251,0.9)] border border-gray-200 backdrop-blur-sm rounded-full text-[0.7rem] font-medium text-gray-500">
+                                <span
+                                    data-testid="graph-stats-entities"
+                                    className="inline-flex items-center gap-[5px] px-2.5 py-[5px] bg-[rgba(249,250,251,0.9)] border border-gray-200 backdrop-blur-sm rounded-full text-[0.7rem] font-medium text-gray-500"
+                                >
                                     <span className="w-[5px] h-[5px] rounded-full bg-blue-500" />
                                     {graphData.total_nodes} entities
                                 </span>
-                                <span className="inline-flex items-center gap-[5px] px-2.5 py-[5px] bg-[rgba(249,250,251,0.9)] border border-gray-200 backdrop-blur-sm rounded-full text-[0.7rem] font-medium text-gray-500">
+                                <span
+                                    data-testid="graph-stats-transactions"
+                                    className="inline-flex items-center gap-[5px] px-2.5 py-[5px] bg-[rgba(249,250,251,0.9)] border border-gray-200 backdrop-blur-sm rounded-full text-[0.7rem] font-medium text-gray-500"
+                                >
                                     <span className="w-[5px] h-[5px] rounded-full bg-emerald-500" />
                                     {graphData.total_transactions.toLocaleString()} transactions
                                     {selectedNode?.transaction_count != null &&
@@ -1039,6 +1045,7 @@ export function GraphExplorerPage({ initialAddress, initialTxHash }: GraphExplor
                                 </span>
                                 {graphData.total_transactions === 0 && graphData.center_address && (
                                     <button
+                                        data-testid="fetch-address"
                                         className="inline-flex items-center gap-[5px] px-3 py-[5px] bg-blue-600 text-white backdrop-blur-sm rounded-full text-[0.7rem] font-semibold border-none cursor-pointer transition-colors hover:bg-blue-700 disabled:opacity-45"
                                         onClick={() => handleIngestAndLoad(graphData.center_address)}
                                         disabled={loading}

--- a/frontend/src/pages/LabelsPage.tsx
+++ b/frontend/src/pages/LabelsPage.tsx
@@ -219,6 +219,7 @@ export function LabelsPage() {
                         <div className="flex flex-col gap-1">
                             <label className={sectionLabel}>Mode</label>
                             <select
+                                data-testid="label-fetch-mode"
                                 className={selectCls}
                                 value={mode}
                                 onChange={(e) => setMode(e.target.value as FetchMode)}
@@ -247,6 +248,7 @@ export function LabelsPage() {
                         <div className="flex flex-col gap-1">
                             <label className={sectionLabel}>Addresses (comma or newline separated)</label>
                             <textarea
+                                data-testid="label-addresses-input"
                                 className={`${inputCls} font-mono min-h-[80px]`}
                                 value={addressesInput}
                                 onChange={(e) => setAddressesInput(e.target.value)}
@@ -258,6 +260,7 @@ export function LabelsPage() {
                         <div className="flex flex-col gap-1">
                             <label className={sectionLabel}>Transaction hashes</label>
                             <textarea
+                                data-testid="label-hashes-input"
                                 className={`${inputCls} font-mono min-h-[80px]`}
                                 value={hashesInput}
                                 onChange={(e) => setHashesInput(e.target.value)}
@@ -269,6 +272,7 @@ export function LabelsPage() {
                         <div className="flex flex-col gap-1">
                             <label className={sectionLabel}>Seed address</label>
                             <input
+                                data-testid="label-seed-input"
                                 className={`${inputCls} font-mono`}
                                 value={seed}
                                 onChange={(e) => setSeed(e.target.value)}
@@ -278,7 +282,7 @@ export function LabelsPage() {
                     )}
 
                     <div>
-                        <button type="submit" disabled={queueing} className={btnPrimary}>
+                        <button type="submit" data-testid="label-queue-submit" disabled={queueing} className={btnPrimary}>
                             {queueing ? "Queueing…" : "Queue fetch"}
                         </button>
                     </div>
@@ -291,6 +295,7 @@ export function LabelsPage() {
                     <h2 className="text-[0.9rem] font-semibold text-gray-900">Tasks</h2>
                     <div className="flex items-center gap-2">
                         <select
+                            data-testid="label-status-filter"
                             className={selectCls}
                             value={statusFilter}
                             onChange={(e) => setStatusFilter(e.target.value as LabelTaskStatus | "all")}
@@ -338,6 +343,8 @@ export function LabelsPage() {
                                         return (
                                             <tr
                                                 key={t.id}
+                                                data-testid="label-task-row"
+                                                data-entity-address={t.entity_address}
                                                 className={`border-t border-gray-100 ${active ? "bg-gray-50" : ""}`}
                                             >
                                                 <td className="px-3 py-2 font-mono text-gray-900">
@@ -356,6 +363,7 @@ export function LabelsPage() {
                                                     {t.status === "pending" || t.status === "running" ? (
                                                         <button
                                                             type="button"
+                                                            data-testid="label-annotate-button"
                                                             onClick={() => openTask(t)}
                                                             className={btnSecondary}
                                                         >
@@ -389,6 +397,7 @@ export function LabelsPage() {
                                 <div className="flex flex-col gap-1">
                                     <label className={sectionLabel}>Entity type</label>
                                     <select
+                                        data-testid="annotation-entity-type"
                                         className={selectCls}
                                         value={annEntityType}
                                         onChange={(e) => setAnnEntityType(e.target.value as EntityType)}
@@ -408,6 +417,7 @@ export function LabelsPage() {
                                             <button
                                                 key={r}
                                                 type="button"
+                                                data-testid={`annotation-risk-${r}`}
                                                 onClick={() => setAnnRisk(r)}
                                                 className={`px-2 py-1 rounded text-[0.7rem] transition-all ${
                                                     annRisk === r
@@ -424,6 +434,7 @@ export function LabelsPage() {
                                 <div className="flex flex-col gap-1">
                                     <label className={sectionLabel}>Labels (comma separated)</label>
                                     <input
+                                        data-testid="annotation-labels"
                                         className={inputCls}
                                         value={annLabelsInput}
                                         onChange={(e) => setAnnLabelsInput(e.target.value)}
@@ -434,6 +445,7 @@ export function LabelsPage() {
                                 <div className="flex flex-col gap-1">
                                     <label className={sectionLabel}>Notes</label>
                                     <textarea
+                                        data-testid="annotation-notes"
                                         className={`${inputCls} min-h-[60px]`}
                                         value={annNotes}
                                         onChange={(e) => setAnnNotes(e.target.value)}
@@ -443,6 +455,7 @@ export function LabelsPage() {
                                 <div className="flex flex-col gap-1">
                                     <label className={sectionLabel}>Evidence (URL or reference)</label>
                                     <input
+                                        data-testid="annotation-evidence"
                                         className={inputCls}
                                         value={annEvidence}
                                         onChange={(e) => setAnnEvidence(e.target.value)}
@@ -452,6 +465,7 @@ export function LabelsPage() {
                                 <div className="flex flex-col gap-1">
                                     <label className={sectionLabel}>Confidence (0–1)</label>
                                     <input
+                                        data-testid="annotation-confidence"
                                         type="number"
                                         step="0.05"
                                         min={0}
@@ -465,7 +479,12 @@ export function LabelsPage() {
                                 </div>
 
                                 <div className="flex gap-2 pt-1">
-                                    <button type="submit" disabled={submittingAnn} className={btnPrimary}>
+                                    <button
+                                        type="submit"
+                                        data-testid="annotation-submit"
+                                        disabled={submittingAnn}
+                                        className={btnPrimary}
+                                    >
                                         {submittingAnn ? "Submitting…" : "Submit"}
                                     </button>
                                     <button

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -64,6 +64,7 @@ export function LoginPage() {
                         </label>
                         <input
                             id="login-email"
+                            data-testid="login-email"
                             type="email"
                             autoComplete="email"
                             className={inputCls}
@@ -82,6 +83,7 @@ export function LoginPage() {
                         <div className="relative">
                             <input
                                 id="login-password"
+                                data-testid="login-password"
                                 type={showPassword ? "text" : "password"}
                                 autoComplete="current-password"
                                 className={`${inputCls} pr-10`}
@@ -127,7 +129,13 @@ export function LoginPage() {
                     </div>
 
                     {/* Submit */}
-                    <button id="login-submit" type="submit" className={`${btnPrimary} mt-1`} disabled={loading}>
+                    <button
+                        id="login-submit"
+                        data-testid="login-submit"
+                        type="submit"
+                        className={`${btnPrimary} mt-1`}
+                        disabled={loading}
+                    >
                         {loading ? (
                             <>
                                 <svg className="animate-spin w-4 h-4" viewBox="0 0 24 24" fill="none">

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
@@ -24,5 +24,8 @@ export default defineConfig({
         changeOrigin: true,
       },
     },
+  },
+  test: {
+    exclude: ['e2e/**', 'node_modules/**', 'dist/**'],
   },
 })


### PR DESCRIPTION
Adds a minimal Playwright E2E smoke journey covering the core analyst flow:

`login → ingest address → explore graph → queue label task → annotate task`

Also wires the smoke test into CI alongside backend validation and Rust ETL tests.

## Changes

- Added Playwright config and E2E smoke spec.
- Added stable `data-testid` selectors for login, explorer search/stats, nav, label queue, and annotation controls.
- Added `test:e2e` frontend script.
- Updated CI to:
  - run Rust ETL `cargo test --workspace`
  - start the Docker Compose app stack for E2E
  - install/run Playwright Chromium smoke test
  - upload Playwright reports on failure
- Excluded E2E specs from Vitest so frontend unit validation does not try to load Playwright tests.
- Fixed annotation JSON persistence by explicitly serializing/casting `labels` and `evidence`.

CI now validates the main user journey through the real frontend, backend, Redis queue, Postgres, and seeded Neo4j graph, catching integration regressions that unit tests and builds would miss.