### PR TITLE
feat/RefToken

### DIFF
--- a/backend/alembic/versions/009_refresh_tokens.py
+++ b/backend/alembic/versions/009_refresh_tokens.py
@@ -1,0 +1,38 @@
+"""Create refresh_tokens table
+
+Revision ID: 009
+Revises: 008
+Create Date: 2026-05-17
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "009"
+down_revision: Union[str, None] = "008"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "refresh_tokens",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("token_hash", sa.String(length=128), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("replaced_by", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], name="fk_refresh_tokens_user_users", ondelete="CASCADE"),
+    )
+    op.create_index("ix_refresh_tokens_user_expires", "refresh_tokens", ["user_id", "expires_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_refresh_tokens_user_expires", table_name="refresh_tokens")
+    op.drop_table("refresh_tokens")

--- a/backend/src/api/models/auth.py
+++ b/backend/src/api/models/auth.py
@@ -44,6 +44,13 @@ class TokenResponse(BaseModel):
     user: UserResponse
 
 
+
+class MessageResponse(BaseModel):
+    """Generic single-field message response."""
+
+    detail: str
+
+
 class ManagedUserCreateRequest(BaseModel):
     """Request body for POST /api/admin/users."""
 

--- a/backend/src/api/routes/auth.py
+++ b/backend/src/api/routes/auth.py
@@ -17,6 +17,7 @@ from db.models import User, UserRole, RefreshToken
 from services.auth import (
     create_access_token,
     decode_access_token,
+    hash_password,
     generate_refresh_token_plaintext,
     hash_refresh_token,
     verify_password,

--- a/backend/src/api/routes/auth.py
+++ b/backend/src/api/routes/auth.py
@@ -2,10 +2,10 @@
 Auth API routes plus shared authentication dependencies.
 """
 
-from datetime import timedelta
+from datetime import timedelta, datetime, timezone
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status, Request, Response
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError
 from sqlalchemy import select
@@ -13,11 +13,12 @@ from sqlalchemy.exc import IntegrityError
 
 from api.deps import RelationalDBDep, SettingsDep
 from api.models.auth import LoginRequest, RegisterRequest, TokenResponse, UserResponse
-from db.models import User, UserRole
+from db.models import User, UserRole, RefreshToken
 from services.auth import (
     create_access_token,
     decode_access_token,
-    hash_password,
+    generate_refresh_token_plaintext,
+    hash_refresh_token,
     verify_password,
 )
 
@@ -41,12 +42,26 @@ def _make_token(user: User, settings) -> str:
 
 
 async def get_current_user(
+    request: Request,
     db: RelationalDBDep,
     settings: SettingsDep,
     credentials: HTTPAuthorizationCredentials | None = Depends(_bearer),
 ) -> User:
-    """Return the authenticated active user from the bearer token."""
-    if credentials is None:
+    """Return the authenticated active user.
+
+    Prefer the access token from the httpOnly cookie, fall back to Authorization header.
+    """
+    token = None
+    # cookie-first
+    cookie_token = request.cookies.get(settings.access_token_cookie_name)
+    if cookie_token:
+        token = cookie_token
+
+    # fallback to Authorization bearer
+    if token is None and credentials is not None:
+        token = credentials.credentials
+
+    if token is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Not authenticated",
@@ -54,11 +69,7 @@ async def get_current_user(
         )
 
     try:
-        payload = decode_access_token(
-            credentials.credentials,
-            settings.jwt_secret_key,
-            settings.jwt_algorithm,
-        )
+        payload = decode_access_token(token, settings.jwt_secret_key, settings.jwt_algorithm)
         user_id: str | None = payload.get("sub")
         if user_id is None:
             raise ValueError("missing sub")
@@ -105,6 +116,7 @@ AdminUserDep = Annotated[User, Depends(require_admin_user)]
 )
 async def register(
     body: RegisterRequest,
+    response: Response,
     db: RelationalDBDep,
     settings: SettingsDep,
 ) -> TokenResponse:
@@ -127,6 +139,37 @@ async def register(
             )
 
     token = _make_token(new_user, settings)
+    # create refresh token record and set cookies
+    refresh_plain = generate_refresh_token_plaintext()
+    refresh_hash = hash_refresh_token(refresh_plain)
+    expires_at = datetime.now(timezone.utc) + timedelta(days=settings.refresh_token_expire_days)
+    async with db.transaction() as session:
+        from db.models import RefreshToken as RT
+
+        rt = RT(user_id=new_user.id, token_hash=refresh_hash, expires_at=expires_at)
+        session.add(rt)
+        await session.flush()
+
+    secure_cookie = settings.environment != "local"
+    response.set_cookie(
+        settings.refresh_token_cookie_name,
+        refresh_plain,
+        httponly=True,
+        secure=secure_cookie,
+        samesite="lax",
+        max_age=settings.refresh_token_expire_days * 24 * 3600,
+        path="/",
+    )
+    # also set short-lived access token cookie
+    response.set_cookie(
+        settings.access_token_cookie_name,
+        token,
+        httponly=True,
+        secure=secure_cookie,
+        samesite="lax",
+        max_age=settings.access_token_expire_minutes * 60,
+        path="/",
+    )
     return TokenResponse(
         access_token=token,
         user=UserResponse.model_validate(new_user),
@@ -136,6 +179,7 @@ async def register(
 @router.post("/login", response_model=TokenResponse)
 async def login(
     body: LoginRequest,
+    response: Response,
     db: RelationalDBDep,
     settings: SettingsDep,
 ) -> TokenResponse:
@@ -160,6 +204,37 @@ async def login(
         )
 
     token = _make_token(user, settings)
+    # create refresh token record and set cookies
+    refresh_plain = generate_refresh_token_plaintext()
+    refresh_hash = hash_refresh_token(refresh_plain)
+    expires_at = datetime.now(timezone.utc) + timedelta(days=settings.refresh_token_expire_days)
+    async with db.transaction() as session:
+        from db.models import RefreshToken as RT
+
+        rt = RT(user_id=user.id, token_hash=refresh_hash, expires_at=expires_at)
+        session.add(rt)
+        await session.flush()
+
+    secure_cookie = settings.environment != "local"
+    response.set_cookie(
+        settings.refresh_token_cookie_name,
+        refresh_plain,
+        httponly=True,
+        secure=secure_cookie,
+        samesite="lax",
+        max_age=settings.refresh_token_expire_days * 24 * 3600,
+        path="/",
+    )
+    response.set_cookie(
+        settings.access_token_cookie_name,
+        token,
+        httponly=True,
+        secure=secure_cookie,
+        samesite="lax",
+        max_age=settings.access_token_expire_minutes * 60,
+        path="/",
+    )
+
     return TokenResponse(
         access_token=token,
         user=UserResponse.model_validate(user),
@@ -172,3 +247,87 @@ async def get_me(
 ) -> UserResponse:
     """Return the profile of the currently authenticated user."""
     return UserResponse.model_validate(current_user)
+
+
+
+@router.post("/refresh", response_model=TokenResponse)
+async def refresh(
+    request: Request,
+    response: Response,
+    db: RelationalDBDep,
+    settings: SettingsDep,
+) -> TokenResponse:
+    """Exchange a valid refresh cookie for a new access token (and rotate refresh token)."""
+    refresh_plain = request.cookies.get(settings.refresh_token_cookie_name)
+    if not refresh_plain:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing refresh token")
+
+    hashed = hash_refresh_token(refresh_plain)
+    async with db.transaction() as session:
+        result = await session.execute(select(RefreshToken).where(RefreshToken.token_hash == hashed))
+        rt = result.scalar_one_or_none()
+        if rt is None or rt.revoked or rt.expires_at <= datetime.now(timezone.utc):
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired refresh token")
+
+        # find user
+        user = await session.get(User, int(rt.user_id))
+        if user is None or not user.is_active:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found or inactive")
+
+        # rotate refresh token
+        new_plain = generate_refresh_token_plaintext()
+        new_hash = hash_refresh_token(new_plain)
+        new_expires = datetime.now(timezone.utc) + timedelta(days=settings.refresh_token_expire_days)
+        from db.models import RefreshToken as RT
+
+        new_rt = RT(user_id=user.id, token_hash=new_hash, expires_at=new_expires)
+        session.add(new_rt)
+        await session.flush()
+
+        # revoke old
+        rt.revoked = True
+        rt.replaced_by = new_rt.id
+        rt.last_used_at = datetime.now(timezone.utc)
+
+    # issue new access token
+    token = _make_token(user, settings)
+    secure_cookie = settings.environment != "local"
+    response.set_cookie(
+        settings.refresh_token_cookie_name,
+        new_plain,
+        httponly=True,
+        secure=secure_cookie,
+        samesite="lax",
+        max_age=settings.refresh_token_expire_days * 24 * 3600,
+        path="/",
+    )
+    response.set_cookie(
+        settings.access_token_cookie_name,
+        token,
+        httponly=True,
+        secure=secure_cookie,
+        samesite="lax",
+        max_age=settings.access_token_expire_minutes * 60,
+        path="/",
+    )
+
+    return TokenResponse(access_token=token, user=UserResponse.model_validate(user))
+
+
+
+@router.post("/logout")
+async def logout(request: Request, response: Response, db: RelationalDBDep, settings: SettingsDep):
+    """Revoke refresh token and clear cookies."""
+    refresh_plain = request.cookies.get(settings.refresh_token_cookie_name)
+    if refresh_plain:
+        hashed = hash_refresh_token(refresh_plain)
+        async with db.transaction() as session:
+            result = await session.execute(select(RefreshToken).where(RefreshToken.token_hash == hashed))
+            rt = result.scalar_one_or_none()
+            if rt:
+                rt.revoked = True
+
+    # clear cookies
+    response.set_cookie(settings.refresh_token_cookie_name, "", max_age=0, expires=0, path="/")
+    response.set_cookie(settings.access_token_cookie_name, "", max_age=0, expires=0, path="/")
+    return {"detail": "Logged out"}

--- a/backend/src/api/routes/auth.py
+++ b/backend/src/api/routes/auth.py
@@ -12,7 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
 from api.deps import RelationalDBDep, SettingsDep
-from api.models.auth import LoginRequest, RegisterRequest, TokenResponse, UserResponse
+from api.models.auth import LoginRequest, RegisterRequest, TokenResponse, UserResponse, MessageResponse
 from db.models import User, UserRole, RefreshToken
 from services.auth import (
     create_access_token,
@@ -316,7 +316,7 @@ async def refresh(
 
 
 
-@router.post("/logout")
+@router.post("/logout", response_model=MessageResponse)
 async def logout(request: Request, response: Response, db: RelationalDBDep, settings: SettingsDep):
     """Revoke refresh token and clear cookies."""
     refresh_plain = request.cookies.get(settings.refresh_token_cookie_name)

--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -99,6 +99,11 @@ class Settings(BaseSettings):
     jwt_secret_key: str = "change-me-in-production-use-a-long-random-secret"
     jwt_algorithm: str = "HS256"
     access_token_expire_minutes: int = 60 * 24  # 24 hours
+    # Refresh token settings
+    refresh_token_expire_days: int = 30
+    refresh_token_cookie_name: str = "refresh_token"
+    access_token_cookie_name: str = "access_token"
+    refresh_token_rotate_on_use: bool = True
 
     # =========================================================================
     # API Configuration

--- a/backend/src/db/models.py
+++ b/backend/src/db/models.py
@@ -121,6 +121,36 @@ class User(Base):
     )
 
 
+class RefreshToken(Base):
+    """Stateful refresh tokens for user sessions.
+
+    Stores a hashed token so that plaintext tokens are never persisted.
+    """
+
+    __tablename__ = "refresh_tokens"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE", name="fk_refresh_tokens_user_users"),
+        nullable=False,
+    )
+    token_hash: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    last_used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    revoked: Mapped[bool] = mapped_column(Boolean, default=False)
+    replaced_by: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    user: Mapped["User"] = relationship("User")
+
+    __table_args__ = (
+        Index("ix_refresh_tokens_user_expires", "user_id", "expires_at"),
+    )
+
+
 class LabelTask(Base):
     """A labeling task for an entity or subgraph."""
 

--- a/backend/src/services/auth.py
+++ b/backend/src/services/auth.py
@@ -8,6 +8,8 @@ from datetime import datetime, timedelta, timezone
 
 import bcrypt
 from jose import JWTError, jwt  # noqa: F401 – re-exported for callers
+import hashlib
+import secrets
 
 
 # ---------------------------------------------------------------------------
@@ -54,9 +56,26 @@ def decode_access_token(token: str, secret_key: str, algorithm: str) -> dict:
     return jwt.decode(token, secret_key, algorithms=[algorithm])
 
 
+# ---------------------------------------------------------------------------
+# Refresh token helpers
+# ---------------------------------------------------------------------------
+
+
+def generate_refresh_token_plaintext(length: int = 48) -> str:
+    """Generate a secure random refresh token (plaintext)."""
+    return secrets.token_urlsafe(length)
+
+
+def hash_refresh_token(token_plain: str) -> str:
+    """Return a sha256 hex digest of the refresh token for DB storage."""
+    return hashlib.sha256(token_plain.encode()).hexdigest()
+
+
 __all__ = [
     "hash_password",
     "verify_password",
     "create_access_token",
     "decode_access_token",
+    "generate_refresh_token_plaintext",
+    "hash_refresh_token",
 ]

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -37,19 +37,8 @@ import type {
 
 const API_BASE = "/api";
 
-const TOKEN_KEY = "ca_access_token";
-
-export function getStoredToken(): string | null {
-    return localStorage.getItem(TOKEN_KEY);
-}
-
-export function setStoredToken(token: string): void {
-    localStorage.setItem(TOKEN_KEY, token);
-}
-
-export function clearStoredToken(): void {
-    localStorage.removeItem(TOKEN_KEY);
-}
+// Authentication tokens are stored server-side in httpOnly cookies.
+// Frontend uses `credentials: 'include'` and a refresh endpoint to obtain new access tokens.
 
 class ApiError extends Error {
     constructor(
@@ -61,18 +50,38 @@ class ApiError extends Error {
     }
 }
 
-async function request<T>(endpoint: string, options: RequestInit = {}, noContent = false): Promise<T> {
+export async function request<T>(endpoint: string, options: RequestInit = {}, noContent = false): Promise<T> {
     const url = `${API_BASE}${endpoint}`;
-    const token = getStoredToken();
-
     const response = await fetch(url, {
         ...options,
+        credentials: "include",
         headers: {
             "Content-Type": "application/json",
-            ...(token ? { Authorization: `Bearer ${token}` } : {}),
             ...options.headers,
         },
     });
+
+    // If access token expired, attempt silent refresh once and retry
+    if (response.status === 401) {
+        const refreshResp = await fetch(`${API_BASE}/auth/refresh`, { method: "POST", credentials: "include" });
+        if (refreshResp.ok) {
+            // retry original request once
+            const retry = await fetch(url, {
+                ...options,
+                credentials: "include",
+                headers: {
+                    "Content-Type": "application/json",
+                    ...options.headers,
+                },
+            });
+            if (!retry.ok) {
+                const errorData = await retry.json().catch(() => ({}));
+                throw new ApiError(errorData.detail || `HTTP ${retry.status}`, retry.status);
+            }
+            if (noContent) return undefined as T;
+            return retry.json();
+        }
+    }
 
     if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -5,14 +5,8 @@
  * Provides login, register, and logout helpers to any component.
  */
 import React, { createContext, useCallback, useContext, useEffect, useState } from "react";
-import {
-    clearStoredToken,
-    fetchMe,
-    getStoredToken,
-    login as apiLogin,
-    register as apiRegister,
-    setStoredToken,
-} from "../api/client";
+import { fetchMe, login as apiLogin, register as apiRegister, } from "../api/client";
+import { request as apiRequest } from "../api/client";
 import type { RegisterRequest, UserResponse } from "../types";
 
 interface AuthContextValue {
@@ -41,34 +35,31 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const [user, setUser] = useState<UserResponse | null>(null);
     const [loading, setLoading] = useState(true);
 
-    // On mount: restore session from localStorage token
+    // On mount: restore session by calling /auth/me (cookies included by client)
     useEffect(() => {
-        const token = getStoredToken();
-        if (!token) {
-            setLoading(false);
-            return;
-        }
         fetchMe()
             .then((u) => setUser(u))
-            .catch(() => clearStoredToken()) // token expired / invalid
+            .catch(() => setUser(null))
             .finally(() => setLoading(false));
     }, []);
 
     const login = useCallback(async (email: string, password: string) => {
         const res = await apiLogin({ email, password });
-        setStoredToken(res.access_token);
         setUser(res.user);
     }, []);
 
     const register = useCallback(async (username: string, email: string, password: string) => {
         const body: RegisterRequest = { username, email, password };
         const res = await apiRegister(body);
-        setStoredToken(res.access_token);
         setUser(res.user);
     }, []);
 
-    const logout = useCallback(() => {
-        clearStoredToken();
+    const logout = useCallback(async () => {
+        try {
+            await apiRequest("/auth/logout", { method: "POST", credentials: "include" }, true);
+        } catch {
+            // ignore errors
+        }
         setUser(null);
     }, []);
 


### PR DESCRIPTION
This PR adds cookie-based refresh token support and removes client-side JWT storage from localStorage.

### What changed

- Added refresh token configuration in backend settings.
- Introduced a `refresh_tokens` table and SQLAlchemy model to store hashed refresh tokens.
- Added refresh token helper functions for generation and hashing.
- Updated auth routes to:
  - issue both access and refresh cookies on login/register
  - support `POST /auth/refresh` for access token renewal
  - support `POST /auth/logout` to revoke refresh tokens and clear cookies
  - read auth from cookie first, with Bearer token fallback for compatibility
- Updated the frontend API client to send credentials with every request and automatically attempt a silent refresh on 401.
- Updated the auth context to restore the session from `/auth/me` instead of localStorage.
- Added a response model for logout to satisfy route response-model checks.

### Security impact

- Moves authentication state out of localStorage and into httpOnly cookies.
- Reduces XSS exposure for long-lived credentials.
- Enables refresh token rotation and server-side revocation of refresh tokens.

### Notes

- Access tokens remain short-lived and are renewed through the refresh endpoint.
- This PR does not yet add full token blacklist infrastructure or CSRF token protection.
  Those are planned follow-ups.