### PR TITLE
feat: worker scale-out, source failover, rate limit, K8s manifests

### DIFF
--- a/backend/alembic/versions/009_label_tasks_pickup_at.py
+++ b/backend/alembic/versions/009_label_tasks_pickup_at.py
@@ -1,0 +1,39 @@
+"""Add pickup_at to label_tasks
+
+Revision ID: 009
+Revises: 008
+Create Date: 2026-05-12
+
+Issue #3 acceptance: measure deep-trace latency from queue pickup to
+completion as a Prometheus histogram. label_tasks already has
+created_at (enqueue time) and completed_at (finish time); pickup_at
+captures the moment the worker actually started the task, so the
+histogram measures *worker time*, not queue wait. Useful for
+distinguishing "deep trace is slow because the worker is busy" from
+"deep trace is slow because Etherscan is slow".
+
+Nullable to keep existing rows valid. Newly-created rows fill it in
+via mark_pickup() in etl-rs/crates/etl/src/ingest/targeted.rs.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "009"
+down_revision: Union[str, None] = "008"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "label_tasks",
+        sa.Column("pickup_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("label_tasks", "pickup_at")

--- a/backend/alembic/versions/009_label_tasks_pickup_at.py
+++ b/backend/alembic/versions/009_label_tasks_pickup_at.py
@@ -4,7 +4,7 @@ Revision ID: 009
 Revises: 008
 Create Date: 2026-05-12
 
-Issue #3 acceptance: measure deep-trace latency from queue pickup to
+Issue #27 acceptance: measure deep-trace latency from queue pickup to
 completion as a Prometheus histogram. label_tasks already has
 created_at (enqueue time) and completed_at (finish time); pickup_at
 captures the moment the worker actually started the task, so the

--- a/backend/src/api/__init__.py
+++ b/backend/src/api/__init__.py
@@ -1,5 +1,1 @@
 """FastAPI application for Chain-Analysis."""
-
-from .main import create_app
-
-__all__ = ["create_app"]

--- a/backend/src/db/models.py
+++ b/backend/src/db/models.py
@@ -155,6 +155,10 @@ class LabelTask(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
+    # Set by the Rust worker's `mark_pickup` when it pulls the task off the
+    # targeted queue. `completed_at - pickup_at` is the worker-time budget
+    # the `label_task_duration_seconds` Prometheus histogram measures.
+    pickup_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
     # Relationships

--- a/compose/etl.yml
+++ b/compose/etl.yml
@@ -29,6 +29,10 @@ services:
     deploy:
       # Horizontal scaling. Override per-environment via the
       # `WORKER_REPLICAS` host env var (Compose substitutes at parse time).
+      # NOTE: `deploy.replicas` is only honoured by Swarm (`docker stack
+      # deploy`). Plain `docker compose up` ignores it — to run N replicas
+      # there, scale explicitly:
+      #   docker compose up -d --scale worker=${WORKER_REPLICAS:-3}
       replicas: ${WORKER_REPLICAS:-3}
     env_file:
       - ./secrets.dev.env

--- a/compose/etl.yml
+++ b/compose/etl.yml
@@ -4,11 +4,20 @@
 # Task C: drains Redis Streams into Neo4j + Postgres.
 services:
   # =============================================================================
-  # Rust worker — single long-running container with three tokio tasks:
+  # Rust worker — horizontally scaled (deploy.replicas) container running
+  # three tokio tasks per replica:
   #   A) BRPOP `ingest:targeted_queue` for user-triggered targeted fetches
-  #   B) periodic refresh of known_labels ∪ high-risk entities
+  #      — multi-reader safe, Redis dispatches each entry to exactly one
+  #      consumer, so replicas naturally share the queue.
+  #   B) periodic refresh of known_labels ∪ high-risk entities — gated by
+  #      a Redis distributed lease (see refresh.rs) so only one replica
+  #      enqueues per interval; the rest sit out the tick.
   #   C) XREADGROUP drain of `ingested_*` streams into Neo4j + Postgres
+  #      — Redis consumer groups are natively multi-consumer; each replica
+  #      registers under a unique `consumer-{pid}` name.
   # Replaces the old `process` container (deleted in Phase I).
+  # `container_name:` is intentionally omitted so multiple replicas can run
+  # with auto-generated names (`chain-analysis-worker-1` etc.).
   # =============================================================================
   worker:
     build:
@@ -16,8 +25,11 @@ services:
       dockerfile: Dockerfile
       target: worker
     image: chain-analysis/worker:local
-    container_name: chain-analysis-worker
     restart: unless-stopped
+    deploy:
+      # Horizontal scaling. Override per-environment via the
+      # `WORKER_REPLICAS` host env var (Compose substitutes at parse time).
+      replicas: ${WORKER_REPLICAS:-3}
     env_file:
       - ./secrets.dev.env
     environment:

--- a/etl-rs/crates/bin/ingest/src/main.rs
+++ b/etl-rs/crates/bin/ingest/src/main.rs
@@ -19,6 +19,7 @@ fn build_source(config: &etl::config::Config) -> Result<DynBlockSource> {
         etherscan_chain_id: config.etherscan_chain_id,
         alchemy_api_key: config.alchemy_api_key.clone(),
         alchemy_base_url: config.alchemy_base_url.clone(),
+        public_rpc_url: config.public_rpc_url.clone(),
     };
     let boxed = make_source(&src_cfg)?;
     Ok(Arc::from(boxed))

--- a/etl-rs/crates/bin/ingest/src/main.rs
+++ b/etl-rs/crates/bin/ingest/src/main.rs
@@ -267,6 +267,13 @@ async fn main() -> Result<()> {
     let config = etl::config::Config::from_env();
     let run_id = uuid::Uuid::new_v4().to_string();
 
+    // Wire the cross-replica rate limiter. Reads <PROVIDER>_RATE_LIMIT_PER_SEC
+    // env vars; sources `acquire(provider)` before every HTTP call. Safe to
+    // call unconditionally — no-op for providers without an env var.
+    if let Err(e) = etl::sources::rate_limiter::init_limiters(&config.redis_url).await {
+        tracing::warn!(error = %e, "rate limiter: init failed, sources will run unthrottled");
+    }
+
     match cli.cmd {
         Some(Cmd::Block {
             start,

--- a/etl-rs/crates/bin/worker/src/main.rs
+++ b/etl-rs/crates/bin/worker/src/main.rs
@@ -38,6 +38,15 @@ async fn main() -> Result<()> {
     let ingest_cfg = Arc::new(cfg.ingest);
     let process_cfg = Arc::new(cfg.process);
 
+    // Cross-replica rate limiter — reads <PROVIDER>_RATE_LIMIT_PER_SEC env
+    // vars and installs a Redis-backed fixed-window counter for each
+    // configured provider. Sources call rate_limiter::acquire(provider)
+    // before every HTTP request. No-op for providers without an env var,
+    // so this is safe to call unconditionally.
+    if let Err(e) = etl::sources::rate_limiter::init_limiters(&ingest_cfg.redis_url).await {
+        tracing::warn!(error = %e, "rate limiter: init failed, sources will run unthrottled");
+    }
+
     let pg = sqlx::PgPool::connect(&process_cfg.postgres_url).await?;
 
     // One ConnectionManager for A+B (queue), a second one implicit inside

--- a/etl-rs/crates/bin/worker/src/refresh.rs
+++ b/etl-rs/crates/bin/worker/src/refresh.rs
@@ -1,6 +1,25 @@
 //! Task B: on a timer, enumerate known_labels + high-risk entities and LPUSH
 //! refresh jobs onto the targeted queue. An in-memory per-address cooldown
 //! prevents re-queuing the same address back-to-back.
+//!
+//! ## Multi-replica safety
+//!
+//! When `worker` runs with `deploy.replicas > 1`, every replica spins up its
+//! own Task B loop on the same schedule. Without coordination they'd LPUSH
+//! the same known-label set N times every interval, multiplying load on
+//! Etherscan and the downstream pipeline. We avoid this with a Redis
+//! **distributed lease** — at the start of each tick, every replica tries
+//! `SET refresh_lease <replica_id> NX EX <ttl>`. Only one wins; the rest
+//! log and skip. The lease auto-expires before the next tick so a crashed
+//! leader doesn't block the world forever; we deliberately do not release
+//! the lease on completion to avoid the clock-skew race where a slow
+//! replica releases a lease another replica has already re-acquired.
+//!
+//! The per-instance `cooldown` HashMap stays as-is: in the rare case lease
+//! ownership flips to a fresh replica, that replica might re-enqueue an
+//! address it has no record of. Downstream `effective_from_block` makes
+//! this cheap (0 new txs fetched, ~1.5s), so we accept the minor waste in
+//! exchange for not needing a shared cooldown store.
 
 use eyre::Result;
 use etl::pipeline::ShutdownHandle;
@@ -9,7 +28,7 @@ use serde_json::json;
 use sqlx::PgPool;
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 /// Default cap on transactions fetched per address per refresh tick.
 /// Whales (Binance hot wallet, 1inch router, etc.) have millions of txs;
@@ -17,6 +36,26 @@ use tracing::{info, warn};
 /// per-address `effective_from_block` ensures the next refresh resumes
 /// where this one left off.
 const DEFAULT_REFRESH_TX_LIMIT: usize = 500;
+
+/// Redis key holding the current lease holder. Single key — there's only
+/// one Task B refresh schedule, so one lease is enough.
+const LEASE_KEY: &str = "refresh_lease";
+
+/// Floor on the lease TTL. If `REFRESH_INTERVAL_SECS` is configured very
+/// short the natural `interval - 30` formula would give a negative or zero
+/// TTL; clamp it so the lease can't be set with a non-positive expiry.
+const MIN_LEASE_TTL_SECS: u64 = 30;
+
+/// Resolve a per-replica identifier for lease attribution. Docker sets
+/// `HOSTNAME` to the container hostname, which is unique per replica when
+/// using `deploy.replicas`. Falls back to a PID-based string for local /
+/// non-containerised runs.
+fn replica_id() -> String {
+    std::env::var("HOSTNAME")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| format!("worker-pid-{}", std::process::id()))
+}
 
 pub async fn run(
     targeted_queue_key: String,
@@ -34,11 +73,20 @@ pub async fn run(
         .and_then(|v| v.parse().ok())
         .filter(|n: &usize| *n > 0)
         .unwrap_or(DEFAULT_REFRESH_TX_LIMIT);
+    let replica = replica_id();
+    // The lease auto-expires before the next tick so a crashed leader
+    // doesn't block forever. 30s of headroom lets a slow refresh finish
+    // before another replica races on it.
+    let lease_ttl_secs = refresh_interval_secs
+        .saturating_sub(30)
+        .max(MIN_LEASE_TTL_SECS);
 
     info!(
+        replica = %replica,
         refresh_interval_secs,
         refresh_cooldown_secs,
         refresh_tx_limit,
+        lease_ttl_secs,
         "Task B: refresh loop starting"
     );
 
@@ -48,6 +96,34 @@ pub async fn run(
         tokio::select! {
             _ = tokio::time::sleep(tick) => {},
             _ = shutdown.wait() => break,
+        }
+
+        // SET refresh_lease <replica> NX EX <ttl> — atomic acquire.
+        // - Ok(Some(_)) → we won this tick.
+        // - Ok(None) → another replica holds the lease; sit out this tick.
+        // - Err(_) → Redis unhappy; log + skip rather than racing without
+        //   the lease (better to drop a tick than double-enqueue).
+        let lease_acquired: redis::RedisResult<Option<String>> = redis::cmd("SET")
+            .arg(LEASE_KEY)
+            .arg(&replica)
+            .arg("NX")
+            .arg("EX")
+            .arg(lease_ttl_secs)
+            .query_async(&mut redis)
+            .await;
+
+        match lease_acquired {
+            Ok(Some(_)) => {
+                debug!(iter, replica = %replica, "Task B: lease acquired");
+            }
+            Ok(None) => {
+                debug!(iter, replica = %replica, "Task B: lease held by another replica, skipping tick");
+                continue;
+            }
+            Err(e) => {
+                warn!(iter, replica = %replica, error = %e, "Task B: lease acquisition failed, skipping tick");
+                continue;
+            }
         }
 
         let tick_started = Instant::now();
@@ -112,6 +188,7 @@ pub async fn run(
 
         info!(
             iter,
+            replica = %replica,
             pushed,
             skipped,
             tick_ms = tick_started.elapsed().as_millis() as u64,

--- a/etl-rs/crates/bin/worker/src/refresh.rs
+++ b/etl-rs/crates/bin/worker/src/refresh.rs
@@ -15,6 +15,15 @@
 //! the lease on completion to avoid the clock-skew race where a slow
 //! replica releases a lease another replica has already re-acquired.
 //!
+//! The lease TTL is `interval - 30`, so there is a ~30s window each tick
+//! where no lease is held. If a second replica's tick happens to land in
+//! that window (clock skew / tick drift) it could win the lease and run a
+//! *second* refresh within the same interval. A shared last-refresh
+//! timestamp (`refresh_last_ts`, written from Redis server `TIME` so it's
+//! consistent across machines) guards that: after winning the lease a
+//! replica still skips if the previous refresh was less than one interval
+//! ago.
+//!
 //! The per-instance `cooldown` HashMap stays as-is: in the rare case lease
 //! ownership flips to a fresh replica, that replica might re-enqueue an
 //! address it has no record of. Downstream `effective_from_block` makes
@@ -41,6 +50,11 @@ const DEFAULT_REFRESH_TX_LIMIT: usize = 500;
 /// one Task B refresh schedule, so one lease is enough.
 const LEASE_KEY: &str = "refresh_lease";
 
+/// Redis key holding the Unix-seconds timestamp of the last refresh tick
+/// that actually ran. Used to suppress a second refresh inside one
+/// interval when the lease gap lets another replica slip through.
+const LAST_REFRESH_KEY: &str = "refresh_last_ts";
+
 /// Floor on the lease TTL. If `REFRESH_INTERVAL_SECS` is configured very
 /// short the natural `interval - 30` formula would give a negative or zero
 /// TTL; clamp it so the lease can't be set with a non-positive expiry.
@@ -55,6 +69,14 @@ fn replica_id() -> String {
         .ok()
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| format!("worker-pid-{}", std::process::id()))
+}
+
+/// Redis server clock in Unix seconds. Using the server's `TIME` rather
+/// than each replica's local clock keeps the last-refresh guard correct
+/// even when worker replicas run on different machines.
+async fn redis_now_secs(redis: &mut ConnectionManager) -> Option<i64> {
+    let res: redis::RedisResult<(i64, i64)> = redis::cmd("TIME").query_async(redis).await;
+    res.ok().map(|(secs, _micros)| secs)
 }
 
 pub async fn run(
@@ -124,6 +146,28 @@ pub async fn run(
                 warn!(iter, replica = %replica, error = %e, "Task B: lease acquisition failed, skipping tick");
                 continue;
             }
+        }
+
+        // Second guard behind the lease: even holding the lease, bail if a
+        // refresh ran less than one interval ago. This closes the lease-gap
+        // window where a drifted replica could double-refresh. Best-effort —
+        // if the Redis clock or read is unavailable we proceed rather than
+        // stall refreshes entirely.
+        let now_secs = redis_now_secs(&mut redis).await;
+        if let Some(now) = now_secs {
+            let last: Option<i64> = redis.get(LAST_REFRESH_KEY).await.ok().flatten();
+            if let Some(last) = last {
+                if now.saturating_sub(last) < refresh_interval_secs as i64 {
+                    debug!(
+                        iter,
+                        replica = %replica,
+                        since_last_secs = now - last,
+                        "Task B: refresh ran <1 interval ago, skipping tick"
+                    );
+                    continue;
+                }
+            }
+            let _: redis::RedisResult<()> = redis.set(LAST_REFRESH_KEY, now).await;
         }
 
         let tick_started = Instant::now();

--- a/etl-rs/crates/etl/src/config.rs
+++ b/etl-rs/crates/etl/src/config.rs
@@ -22,12 +22,17 @@ pub struct Config {
     pub targeted_queue_key: String,
     /// Postgres URL for targeted-ingest modes that query `label_tasks`.
     pub postgres_url: Option<String>,
-    /// Data-source selector: `"etherscan"` | `"alchemy"` | `"mock"`. Unset →
-    /// inferred from whichever provider key is populated, defaulting to mock.
+    /// Data-source selector: `"etherscan"` | `"alchemy"` | `"public_rpc"` |
+    /// `"failover"` | `"mock"`. Unset → inferred from whichever provider key
+    /// is populated, defaulting to mock.
     pub ingest_source: Option<String>,
     pub alchemy_api_key: Option<String>,
     pub alchemy_base_url: String,
     pub alchemy_chain: String,
+    /// Endpoint for the keyless public RPC tier. Used by `INGEST_SOURCE=public_rpc`
+    /// and as the last fallback in `INGEST_SOURCE=failover`. Unset → the
+    /// `sources::public_rpc::DEFAULT_PUBLIC_RPC_URL` default (Ankr).
+    pub public_rpc_url: Option<String>,
 }
 
 impl Config {
@@ -56,6 +61,9 @@ impl Config {
                 "https://eth-mainnet.g.alchemy.com/v2/",
             ),
             alchemy_chain: env_or("ALCHEMY_CHAIN", "eth-mainnet"),
+            public_rpc_url: std::env::var("PUBLIC_RPC_URL")
+                .ok()
+                .filter(|s| !s.is_empty()),
         }
     }
 }

--- a/etl-rs/crates/etl/src/ingest/targeted.rs
+++ b/etl-rs/crates/etl/src/ingest/targeted.rs
@@ -1,4 +1,6 @@
 use eyre::Result;
+use metrics::histogram;
+use crate::observability::LABEL_TASK_DURATION_SECONDS;
 use crate::pipeline::ProgressReporter;
 use serde::Deserialize;
 use crate::sinks::postgres_writer::PostgresWriter;
@@ -81,6 +83,17 @@ pub enum QueuedSpec {
         seed: String,
         hops: u8,
     },
+}
+
+/// Short static tag describing a `QueuedSpec` variant. Used as a Prometheus
+/// label value on `label_task_duration_seconds`, so the histogram can be
+/// broken down by mode in Grafana without parsing the JSON payload.
+fn spec_kind(spec: &QueuedSpec) -> &'static str {
+    match spec {
+        QueuedSpec::Addresses { .. } => "addresses",
+        QueuedSpec::Hashes { .. } => "hashes",
+        QueuedSpec::Neighborhood { .. } => "neighborhood",
+    }
 }
 
 impl From<QueuedSpec> for TargetSpec {
@@ -416,10 +429,16 @@ pub struct TargetedJob<'a> {
 
 impl<'a> TargetedJob<'a> {
     /// Full lifecycle for a queue payload: pickup → run → terminal. Returns
-    /// the number of transactions ingested on success.
+    /// the number of transactions ingested on success. Records the wall-
+    /// clock duration into [`LABEL_TASK_DURATION_SECONDS`] labelled by spec
+    /// kind and outcome so dashboards can split deep-trace from single-
+    /// address fetches and happy-path latency from failure-path latency.
     pub async fn execute(&mut self, task: QueuedTask) -> Result<u64> {
         let QueuedTask { task_id, run_id, spec } = task;
         info!(?task_id, ?run_id, "Picked up targeted entry");
+
+        let kind = spec_kind(&spec);
+        let started = Instant::now();
 
         Self::mark_pickup(self.pg, task_id, run_id.as_deref()).await;
         let result = run_targeted(
@@ -433,13 +452,27 @@ impl<'a> TargetedJob<'a> {
         )
         .await;
         Self::mark_terminal(self.pg, task_id, run_id.as_deref(), &result).await;
+
+        let outcome = if result.is_ok() { "success" } else { "failure" };
+        histogram!(
+            LABEL_TASK_DURATION_SECONDS,
+            "kind" => kind,
+            "outcome" => outcome,
+        )
+        .record(started.elapsed().as_secs_f64());
+
         result
     }
 
     async fn mark_pickup(pg: &PgPool, task_id: Option<i64>, run_id: Option<&str>) {
         if let Some(tid) = task_id {
+            // pickup_at = NOW() drives the `label_task_duration_seconds`
+            // Prometheus histogram (see observability.rs) and is useful
+            // for ad-hoc SQL like "median time spent in queue vs running".
             if let Err(e) = sqlx::query(
-                "UPDATE label_tasks SET status='running', updated_at=NOW() WHERE id=$1",
+                "UPDATE label_tasks
+                    SET status='running', pickup_at=NOW(), updated_at=NOW()
+                  WHERE id=$1",
             )
             .bind(tid)
             .execute(pg)

--- a/etl-rs/crates/etl/src/ingest/targeted.rs
+++ b/etl-rs/crates/etl/src/ingest/targeted.rs
@@ -438,9 +438,10 @@ impl<'a> TargetedJob<'a> {
         info!(?task_id, ?run_id, "Picked up targeted entry");
 
         let kind = spec_kind(&spec);
-        let started = Instant::now();
 
         Self::mark_pickup(self.pg, task_id, run_id.as_deref()).await;
+        // Time from pickup to terminal, mirroring the `pickup_at` column.
+        let started = Instant::now();
         let result = run_targeted(
             self.config,
             spec.into(),

--- a/etl-rs/crates/etl/src/observability.rs
+++ b/etl-rs/crates/etl/src/observability.rs
@@ -37,6 +37,14 @@ pub const CONSUMER_BATCH_DURATION: &str = "consumer_batch_duration_seconds";
 pub const DLQ_MOVES: &str = "dlq_moves_total";
 pub const DLQ_MESSAGES_MOVED: &str = "dlq_messages_moved_total";
 
+// Targeted (Task A) — user-triggered ingest end-to-end latency.
+// Time from `mark_pickup` (worker picks up the queued task) to
+// `mark_terminal` (worker writes the final status). Labelled by `kind`
+// (addresses / hashes / neighborhood) and `outcome` (success / failure)
+// so dashboards can break down deep-trace vs single-address vs whole-hash
+// fetches and separate happy-path latency from failure-path latency.
+pub const LABEL_TASK_DURATION_SECONDS: &str = "label_task_duration_seconds";
+
 // ---------------------------------------------------------------------------
 // Init
 // ---------------------------------------------------------------------------
@@ -123,5 +131,11 @@ fn describe_metrics() {
     describe_counter!(
         DLQ_MESSAGES_MOVED,
         "Individual messages moved to DLQ streams (labels: stream)"
+    );
+
+    describe_histogram!(
+        LABEL_TASK_DURATION_SECONDS,
+        Unit::Seconds,
+        "End-to-end worker time for a targeted task, from queue pickup to terminal status (labels: kind, outcome)"
     );
 }

--- a/etl-rs/crates/etl/src/sources/alchemy/block.rs
+++ b/etl-rs/crates/etl/src/sources/alchemy/block.rs
@@ -9,8 +9,8 @@ use crate::types::Transaction;
 use super::rpc;
 use super::super::etherscan::hex;
 
-pub async fn eth_block_number(client: &Client, url: &str) -> Result<u64> {
-    let result = rpc::call(client, url, "eth_blockNumber", json!([])).await?;
+pub async fn eth_block_number(provider: &'static str, client: &Client, url: &str) -> Result<u64> {
+    let result = rpc::call(provider, client, url, "eth_blockNumber", json!([])).await?;
     let s = result
         .as_str()
         .ok_or_else(|| eyre::eyre!("eth_blockNumber: expected hex string"))?;
@@ -18,12 +18,14 @@ pub async fn eth_block_number(client: &Client, url: &str) -> Result<u64> {
 }
 
 pub async fn eth_get_block_by_number(
+    provider: &'static str,
     client: &Client,
     url: &str,
     block_num: u64,
 ) -> Result<Vec<Transaction>> {
     let tag = format!("0x{:x}", block_num);
     let result = rpc::call(
+        provider,
         client,
         url,
         "eth_getBlockByNumber",
@@ -59,11 +61,13 @@ pub async fn eth_get_block_by_number(
 }
 
 pub async fn eth_get_transaction_by_hash(
+    provider: &'static str,
     client: &Client,
     url: &str,
     tx_hash: &str,
 ) -> Result<Option<Transaction>> {
     let result = rpc::call(
+        provider,
         client,
         url,
         "eth_getTransactionByHash",

--- a/etl-rs/crates/etl/src/sources/alchemy/logs.rs
+++ b/etl-rs/crates/etl/src/sources/alchemy/logs.rs
@@ -17,14 +17,19 @@ use super::super::etherscan::hex;
 pub const TRANSFER_TOPIC0: &str =
     "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
 
-pub async fn fetch_transfers(client: &Client, url: &str, block_num: u64) -> Result<Vec<Transfer>> {
+pub async fn fetch_transfers(
+    provider: &'static str,
+    client: &Client,
+    url: &str,
+    block_num: u64,
+) -> Result<Vec<Transfer>> {
     let tag = format!("0x{:x}", block_num);
     let params = json!([{
         "fromBlock": tag,
         "toBlock": tag,
         "topics": [TRANSFER_TOPIC0],
     }]);
-    let result = rpc::call(client, url, "eth_getLogs", params).await?;
+    let result = rpc::call(provider, client, url, "eth_getLogs", params).await?;
     let entries = result.as_array().cloned().unwrap_or_default();
 
     let mut out = Vec::with_capacity(entries.len());

--- a/etl-rs/crates/etl/src/sources/alchemy/mod.rs
+++ b/etl-rs/crates/etl/src/sources/alchemy/mod.rs
@@ -41,21 +41,27 @@ impl AlchemySource {
     }
 }
 
+/// Tag identifying this source for the rate-limiter bucket. Lives as a
+/// const so `&'static str` plumbing matches the alchemy submodule signature.
+const PROVIDER: &str = "alchemy";
+
 #[async_trait]
 impl BlockSource for AlchemySource {
     fn name(&self) -> &'static str {
-        "alchemy"
+        PROVIDER
     }
 
     async fn latest_block(&self) -> Result<u64> {
-        block::eth_block_number(&self.client, &self.url).await
+        block::eth_block_number(PROVIDER, &self.client, &self.url).await
     }
 
     async fn fetch_block(&self, block_num: u64) -> Result<Vec<Transaction>> {
-        let mut txs = block::eth_get_block_by_number(&self.client, &self.url, block_num).await?;
+        let mut txs =
+            block::eth_get_block_by_number(PROVIDER, &self.client, &self.url, block_num).await?;
         // Enrich with receipts (gas_used, contract_address). Non-fatal on failure.
-        if let Err(e) = receipts::enrich_with_receipts(&self.client, &self.url, block_num, &mut txs)
-            .await
+        if let Err(e) =
+            receipts::enrich_with_receipts(PROVIDER, &self.client, &self.url, block_num, &mut txs)
+                .await
         {
             tracing::warn!(block = block_num, error = %e, "receipt enrichment failed");
         }
@@ -63,14 +69,14 @@ impl BlockSource for AlchemySource {
     }
 
     async fn fetch_traces(&self, block_num: u64) -> Result<Vec<Trace>> {
-        traces::trace_block(&self.client, &self.url, block_num).await
+        traces::trace_block(PROVIDER, &self.client, &self.url, block_num).await
     }
 
     async fn fetch_transfers(&self, block_num: u64) -> Result<Vec<Transfer>> {
-        logs::fetch_transfers(&self.client, &self.url, block_num).await
+        logs::fetch_transfers(PROVIDER, &self.client, &self.url, block_num).await
     }
 
     async fn fetch_tx_by_hash(&self, tx_hash: &str) -> Result<Option<Transaction>> {
-        block::eth_get_transaction_by_hash(&self.client, &self.url, tx_hash).await
+        block::eth_get_transaction_by_hash(PROVIDER, &self.client, &self.url, tx_hash).await
     }
 }

--- a/etl-rs/crates/etl/src/sources/alchemy/receipts.rs
+++ b/etl-rs/crates/etl/src/sources/alchemy/receipts.rs
@@ -12,6 +12,7 @@ use super::rpc;
 use super::super::etherscan::hex;
 
 pub async fn enrich_with_receipts(
+    provider: &'static str,
     client: &Client,
     url: &str,
     block_num: u64,
@@ -21,7 +22,7 @@ pub async fn enrich_with_receipts(
         return Ok(());
     }
     let tag = format!("0x{:x}", block_num);
-    let result = rpc::call(client, url, "eth_getBlockReceipts", json!([tag])).await?;
+    let result = rpc::call(provider, client, url, "eth_getBlockReceipts", json!([tag])).await?;
     let receipts = result.as_array().cloned().unwrap_or_default();
 
     // Map tx_hash → (gasUsed, contractAddress)

--- a/etl-rs/crates/etl/src/sources/alchemy/rpc.rs
+++ b/etl-rs/crates/etl/src/sources/alchemy/rpc.rs
@@ -1,11 +1,15 @@
 //! Thin JSON-RPC envelope over reqwest. Handles 429 retries with exponential
 //! backoff (same policy as Etherscan), extracts the `result` or `error` field.
+//! Shared between `AlchemySource` and `PublicRpcSource`; the `provider` arg
+//! routes calls to the right rate-limit bucket (`alchemy` vs `public_rpc`).
 
 use eyre::{bail, Result};
 use reqwest::Client;
 use serde_json::{json, Value};
 use std::time::Duration;
 use tracing::warn;
+
+use crate::sources::rate_limiter;
 
 const MAX_RETRIES: u32 = 5;
 const INITIAL_BACKOFF: Duration = Duration::from_millis(250);
@@ -15,7 +19,13 @@ const MAX_BACKOFF: Duration = Duration::from_secs(5);
 ///
 /// Errors if the response contains an `error` object or HTTP status is
 /// non-success after retries.
-pub async fn call(client: &Client, url: &str, method: &str, params: Value) -> Result<Value> {
+pub async fn call(
+    provider: &'static str,
+    client: &Client,
+    url: &str,
+    method: &str,
+    params: Value,
+) -> Result<Value> {
     let body = json!({
         "jsonrpc": "2.0",
         "id": 1,
@@ -28,6 +38,11 @@ pub async fn call(client: &Client, url: &str, method: &str, params: Value) -> Re
 
     loop {
         attempt += 1;
+        // Drain a token from the per-provider bucket before each attempt.
+        // The retry loop below is *additional* defence against the rare 429
+        // that slips past the limiter (e.g. burst beyond capacity, clock
+        // skew between replicas).
+        rate_limiter::acquire(provider).await;
         let resp = client.post(url).json(&body).send().await?;
 
         if resp.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {

--- a/etl-rs/crates/etl/src/sources/alchemy/traces.rs
+++ b/etl-rs/crates/etl/src/sources/alchemy/traces.rs
@@ -11,9 +11,14 @@ use crate::types::Trace;
 use super::rpc;
 use super::super::etherscan::hex;
 
-pub async fn trace_block(client: &Client, url: &str, block_num: u64) -> Result<Vec<Trace>> {
+pub async fn trace_block(
+    provider: &'static str,
+    client: &Client,
+    url: &str,
+    block_num: u64,
+) -> Result<Vec<Trace>> {
     let tag = format!("0x{:x}", block_num);
-    let result = rpc::call(client, url, "trace_block", json!([tag])).await?;
+    let result = rpc::call(provider, client, url, "trace_block", json!([tag])).await?;
     let entries = result.as_array().cloned().unwrap_or_default();
 
     let mut out = Vec::with_capacity(entries.len());

--- a/etl-rs/crates/etl/src/sources/block_source.rs
+++ b/etl-rs/crates/etl/src/sources/block_source.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use eyre::Result;
+use std::sync::Arc;
 use crate::types::{Trace, Transaction, Transfer};
 
 /// Provider-agnostic interface for fetching on-chain block data. One impl per
@@ -23,13 +24,18 @@ pub trait BlockSource: Send + Sync {
 /// Kept as a plain struct so the `sources` crate stays independent of `config`.
 #[derive(Debug, Clone)]
 pub struct SourceConfig {
-    /// Explicit selection: "etherscan" | "alchemy" | "mock". None → inferred.
+    /// Explicit selection: "etherscan" | "alchemy" | "public_rpc" | "failover"
+    /// | "mock". None → inferred.
     pub ingest_source: Option<String>,
     pub etherscan_api_key: Option<String>,
     pub etherscan_base_url: String,
     pub etherscan_chain_id: u64,
     pub alchemy_api_key: Option<String>,
     pub alchemy_base_url: String,
+    /// Endpoint for the keyless public RPC tier (used by `public_rpc` and
+    /// as the last fallback inside `failover`). `None` → falls back to
+    /// `super::public_rpc::DEFAULT_PUBLIC_RPC_URL`.
+    pub public_rpc_url: Option<String>,
 }
 
 /// Build a `BlockSource` from config. Selection rules:
@@ -44,29 +50,64 @@ pub fn make_source(cfg: &SourceConfig) -> Result<Box<dyn BlockSource>> {
 
     match selected.as_str() {
         "mock" => Ok(Box::new(super::mock::MockSource)),
-        "etherscan" => {
-            let key = cfg
+        "etherscan" => Ok(Box::new(build_etherscan(cfg)?)),
+        "alchemy" => Ok(Box::new(build_alchemy(cfg)?)),
+        "public_rpc" => Ok(Box::new(build_public_rpc(cfg))),
+        "failover" => {
+            // Build the failover ladder in priority order. Skip tiers whose
+            // credentials are missing — public_rpc is always available as
+            // last resort because it needs no key.
+            let mut tiers: Vec<Arc<dyn BlockSource>> = Vec::new();
+            if cfg
                 .etherscan_api_key
                 .as_deref()
-                .ok_or_else(|| eyre::eyre!("ETHERSCAN_API_KEY required for etherscan source"))?;
-            Ok(Box::new(super::etherscan::EtherscanSource::new(
-                cfg.etherscan_base_url.clone(),
-                key.to_string(),
-                cfg.etherscan_chain_id,
-            )))
-        }
-        "alchemy" => {
-            let key = cfg
+                .is_some_and(|s| !s.is_empty())
+            {
+                tiers.push(Arc::new(build_etherscan(cfg)?));
+            }
+            if cfg
                 .alchemy_api_key
                 .as_deref()
-                .ok_or_else(|| eyre::eyre!("ALCHEMY_API_KEY required for alchemy source"))?;
-            Ok(Box::new(super::alchemy::AlchemySource::new(
-                cfg.alchemy_base_url.clone(),
-                key.to_string(),
-            )))
+                .is_some_and(|s| !s.is_empty())
+            {
+                tiers.push(Arc::new(build_alchemy(cfg)?));
+            }
+            tiers.push(Arc::new(build_public_rpc(cfg)));
+            Ok(Box::new(super::failover::FailoverSource::new(tiers)?))
         }
         other => Err(eyre::eyre!("unknown INGEST_SOURCE: {}", other)),
     }
+}
+
+fn build_etherscan(cfg: &SourceConfig) -> Result<super::etherscan::EtherscanSource> {
+    let key = cfg
+        .etherscan_api_key
+        .as_deref()
+        .ok_or_else(|| eyre::eyre!("ETHERSCAN_API_KEY required for etherscan source"))?;
+    Ok(super::etherscan::EtherscanSource::new(
+        cfg.etherscan_base_url.clone(),
+        key.to_string(),
+        cfg.etherscan_chain_id,
+    ))
+}
+
+fn build_alchemy(cfg: &SourceConfig) -> Result<super::alchemy::AlchemySource> {
+    let key = cfg
+        .alchemy_api_key
+        .as_deref()
+        .ok_or_else(|| eyre::eyre!("ALCHEMY_API_KEY required for alchemy source"))?;
+    Ok(super::alchemy::AlchemySource::new(
+        cfg.alchemy_base_url.clone(),
+        key.to_string(),
+    ))
+}
+
+fn build_public_rpc(cfg: &SourceConfig) -> super::public_rpc::PublicRpcSource {
+    let url = cfg
+        .public_rpc_url
+        .clone()
+        .unwrap_or_else(|| super::public_rpc::DEFAULT_PUBLIC_RPC_URL.to_string());
+    super::public_rpc::PublicRpcSource::new(url)
 }
 
 fn infer(cfg: &SourceConfig) -> &'static str {
@@ -95,6 +136,7 @@ mod tests {
             etherscan_chain_id: 1,
             alchemy_api_key: None,
             alchemy_base_url: "https://eth-mainnet.g.alchemy.com/v2/".into(),
+            public_rpc_url: None,
         }
     }
 
@@ -142,5 +184,33 @@ mod tests {
         let mut cfg = base_cfg();
         cfg.ingest_source = Some("infura".into());
         assert!(make_source(&cfg).is_err());
+    }
+
+    #[test]
+    fn make_source_public_rpc_needs_no_keys() {
+        let mut cfg = base_cfg();
+        cfg.ingest_source = Some("public_rpc".into());
+        let src = make_source(&cfg).unwrap();
+        assert_eq!(src.name(), "public_rpc");
+    }
+
+    #[test]
+    fn make_source_failover_always_succeeds_with_at_least_public_rpc() {
+        // Even without any provider keys, failover falls back to public RPC.
+        let mut cfg = base_cfg();
+        cfg.ingest_source = Some("failover".into());
+        let src = make_source(&cfg).unwrap();
+        assert_eq!(src.name(), "failover");
+    }
+
+    #[test]
+    fn make_source_failover_includes_etherscan_when_key_present() {
+        let mut cfg = base_cfg();
+        cfg.ingest_source = Some("failover".into());
+        cfg.etherscan_api_key = Some("abc".into());
+        // Construction shouldn't fail; the actual ladder is exercised via
+        // FailoverSource's own tests with mocks.
+        let src = make_source(&cfg).unwrap();
+        assert_eq!(src.name(), "failover");
     }
 }

--- a/etl-rs/crates/etl/src/sources/etherscan/address.rs
+++ b/etl-rs/crates/etl/src/sources/etherscan/address.rs
@@ -1,3 +1,4 @@
+use crate::sources::rate_limiter;
 use crate::types::{Trace, Transaction, Transfer};
 use eyre::{bail, Result};
 use reqwest::Client;
@@ -7,6 +8,9 @@ use std::time::Duration;
 use tracing::{debug, info, warn};
 
 use super::hex;
+
+/// Rate-limiter bucket tag for every Etherscan HTTP call in this module.
+const PROVIDER: &str = "etherscan";
 
 const MAX_RETRIES: u32 = 5;
 const INITIAL_BACKOFF: Duration = Duration::from_millis(250);
@@ -76,6 +80,7 @@ pub async fn fetch_address_transactions(
 
     loop {
         attempt += 1;
+        rate_limiter::acquire(PROVIDER).await;
 
         let response = client
             .get(base_url)
@@ -171,6 +176,7 @@ pub async fn fetch_address_internal_txs(
 
     loop {
         attempt += 1;
+        rate_limiter::acquire(PROVIDER).await;
 
         let response = client
             .get(base_url)
@@ -272,6 +278,7 @@ pub async fn fetch_address_token_transfers(
 
     loop {
         attempt += 1;
+        rate_limiter::acquire(PROVIDER).await;
 
         let response = client
             .get(base_url)

--- a/etl-rs/crates/etl/src/sources/etherscan/block.rs
+++ b/etl-rs/crates/etl/src/sources/etherscan/block.rs
@@ -1,3 +1,4 @@
+use crate::sources::rate_limiter;
 use crate::types::Transaction;
 use eyre::{bail, Result};
 use reqwest::Client;
@@ -6,6 +7,9 @@ use std::time::Duration;
 use tracing::{debug, warn};
 
 use super::hex;
+
+/// Rate-limiter bucket tag for every Etherscan HTTP call in this module.
+const PROVIDER: &str = "etherscan";
 
 const MAX_RETRIES: u32 = 5;
 const INITIAL_BACKOFF: Duration = Duration::from_millis(250);
@@ -24,6 +28,7 @@ pub async fn fetch_latest_block_number(
 
     loop {
         attempt += 1;
+        rate_limiter::acquire(PROVIDER).await;
 
         let response = client
             .get(base_url)
@@ -74,6 +79,7 @@ pub async fn fetch_block_transactions(
 
     loop {
         attempt += 1;
+        rate_limiter::acquire(PROVIDER).await;
 
         let response = client
             .get(base_url)

--- a/etl-rs/crates/etl/src/sources/etherscan/erc20.rs
+++ b/etl-rs/crates/etl/src/sources/etherscan/erc20.rs
@@ -1,3 +1,4 @@
+use crate::sources::rate_limiter;
 use crate::types::Transfer;
 use eyre::{bail, Result};
 use reqwest::Client;
@@ -6,6 +7,8 @@ use std::time::Duration;
 use tracing::{debug, warn};
 
 use super::hex;
+
+const PROVIDER: &str = "etherscan";
 
 const ERC20_TRANSFER_TOPIC: &str =
     "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
@@ -29,6 +32,7 @@ pub async fn fetch_block_transfers(
 
     loop {
         attempt += 1;
+        rate_limiter::acquire(PROVIDER).await;
 
         let response = client
             .get(base_url)

--- a/etl-rs/crates/etl/src/sources/etherscan/traces.rs
+++ b/etl-rs/crates/etl/src/sources/etherscan/traces.rs
@@ -1,3 +1,4 @@
+use crate::sources::rate_limiter;
 use crate::types::Trace;
 use eyre::{bail, Result};
 use reqwest::Client;
@@ -6,6 +7,8 @@ use std::time::Duration;
 use tracing::{debug, warn};
 
 use super::hex;
+
+const PROVIDER: &str = "etherscan";
 
 const MAX_RETRIES: u32 = 5;
 const INITIAL_BACKOFF: Duration = Duration::from_millis(250);
@@ -25,6 +28,7 @@ pub async fn fetch_block_traces(
 
     loop {
         attempt += 1;
+        rate_limiter::acquire(PROVIDER).await;
 
         let response = client
             .get(base_url)

--- a/etl-rs/crates/etl/src/sources/etherscan/tx.rs
+++ b/etl-rs/crates/etl/src/sources/etherscan/tx.rs
@@ -3,9 +3,12 @@ use reqwest::Client;
 use serde_json::Value;
 use std::time::Duration;
 use tracing::warn;
+use crate::sources::rate_limiter;
 use crate::types::Transaction;
 
 use super::hex;
+
+const PROVIDER: &str = "etherscan";
 
 const MAX_RETRIES: u32 = 5;
 const INITIAL_BACKOFF: Duration = Duration::from_millis(250);
@@ -26,6 +29,7 @@ pub async fn fetch_by_hash(
 
     loop {
         attempt += 1;
+        rate_limiter::acquire(PROVIDER).await;
         let response = client
             .get(base_url)
             .query(&[

--- a/etl-rs/crates/etl/src/sources/failover.rs
+++ b/etl-rs/crates/etl/src/sources/failover.rs
@@ -9,7 +9,7 @@
 //! `FailoverSource` is constructed; each method tries them top-down.
 //!
 //! Per-source rate limiting is **out of scope here** — see the Redis
-//! token-bucket limiter in `sources::rate_limiter`. This module only handles
+//! fixed-window limiter in `sources::rate_limiter`. This module only handles
 //! the "which source did the call land on" question.
 
 use async_trait::async_trait;

--- a/etl-rs/crates/etl/src/sources/failover.rs
+++ b/etl-rs/crates/etl/src/sources/failover.rs
@@ -1,0 +1,278 @@
+//! A [`BlockSource`] that delegates to an ordered list of underlying sources,
+//! falling back to the next on **recoverable** errors (HTTP 429, 5xx,
+//! connection/DNS, timeout). Hard errors (auth, parse, missing data) propagate
+//! immediately so we don't mask a real bug by silently switching tiers.
+//!
+//! Typical configuration: `[etherscan, alchemy, public_rpc]` — Etherscan
+//! free-tier is the cheapest 5 req/s, Alchemy provides headroom when a paid
+//! key is configured, public RPC catches the rest. The order is set when the
+//! `FailoverSource` is constructed; each method tries them top-down.
+//!
+//! Per-source rate limiting is **out of scope here** — see the Redis
+//! token-bucket limiter in `sources::rate_limiter`. This module only handles
+//! the "which source did the call land on" question.
+
+use async_trait::async_trait;
+use eyre::{eyre, Result};
+use std::sync::Arc;
+use tracing::warn;
+
+use super::block_source::BlockSource;
+use crate::types::{Trace, Transaction, Transfer};
+
+pub struct FailoverSource {
+    sources: Vec<Arc<dyn BlockSource>>,
+}
+
+impl FailoverSource {
+    /// Construct from an ordered list (highest priority first). Empty list
+    /// is rejected to surface a misconfiguration at startup rather than
+    /// later as a confusing "all sources exhausted" error per call.
+    pub fn new(sources: Vec<Arc<dyn BlockSource>>) -> Result<Self> {
+        if sources.is_empty() {
+            return Err(eyre!(
+                "FailoverSource requires at least one underlying source"
+            ));
+        }
+        Ok(Self { sources })
+    }
+
+    pub fn tier_names(&self) -> Vec<&'static str> {
+        self.sources.iter().map(|s| s.name()).collect()
+    }
+}
+
+/// Classify an error from an underlying source: recoverable means the
+/// failover ladder should try the next tier; hard means propagate.
+///
+/// Conservative: only match on patterns that genuinely indicate transient
+/// provider trouble. Anything else (auth, malformed response) is hard so
+/// we don't mask real bugs by silently switching tiers.
+fn is_recoverable(err: &eyre::Report) -> bool {
+    let s = format!("{:#}", err).to_lowercase();
+    // HTTP rate limit
+    s.contains("429") || s.contains("rate limit") || s.contains("too many requests")
+        // HTTP 5xx — the alchemy/etherscan callers stringify status as
+        // "HTTP 5xx" so a substring match is enough.
+        || s.contains("http 50") || s.contains("http 51") || s.contains("http 52")
+        || s.contains("http 53") || s.contains("http 54") || s.contains("http 59")
+        // Network / DNS
+        || s.contains("timeout") || s.contains("timed out")
+        || s.contains("connection") || s.contains("dns")
+        // reqwest's "error sending request" — typically a transport failure
+        || s.contains("error sending request")
+}
+
+/// Try each source in order; on a recoverable error, log and continue;
+/// on a hard error, return immediately; on success, return the value.
+/// Designed as a generic so all five `BlockSource` methods share the same
+/// loop without duplicated logic.
+async fn try_each<T, F, Fut>(
+    sources: &[Arc<dyn BlockSource>],
+    op_name: &'static str,
+    mut op: F,
+) -> Result<T>
+where
+    F: FnMut(Arc<dyn BlockSource>) -> Fut,
+    Fut: std::future::Future<Output = Result<T>>,
+{
+    let mut last_err: Option<eyre::Report> = None;
+    for src in sources {
+        match op(Arc::clone(src)).await {
+            Ok(v) => return Ok(v),
+            Err(e) if is_recoverable(&e) => {
+                warn!(
+                    op = op_name,
+                    source = src.name(),
+                    error = %e,
+                    "failover: recoverable error, trying next tier"
+                );
+                last_err = Some(e);
+                continue;
+            }
+            Err(e) => {
+                // Non-recoverable: don't burn budget on the next tier.
+                return Err(e.wrap_err(format!(
+                    "{} failed (non-recoverable) on source {}",
+                    op_name,
+                    src.name()
+                )));
+            }
+        }
+    }
+    Err(last_err
+        .unwrap_or_else(|| eyre!("{}: all sources exhausted with no error", op_name))
+        .wrap_err(format!("{}: all sources exhausted", op_name)))
+}
+
+#[async_trait]
+impl BlockSource for FailoverSource {
+    fn name(&self) -> &'static str {
+        "failover"
+    }
+
+    async fn latest_block(&self) -> Result<u64> {
+        try_each(&self.sources, "latest_block", |s| async move {
+            s.latest_block().await
+        })
+        .await
+    }
+
+    async fn fetch_block(&self, block_num: u64) -> Result<Vec<Transaction>> {
+        try_each(&self.sources, "fetch_block", |s| async move {
+            s.fetch_block(block_num).await
+        })
+        .await
+    }
+
+    async fn fetch_traces(&self, block_num: u64) -> Result<Vec<Trace>> {
+        try_each(&self.sources, "fetch_traces", |s| async move {
+            s.fetch_traces(block_num).await
+        })
+        .await
+    }
+
+    async fn fetch_transfers(&self, block_num: u64) -> Result<Vec<Transfer>> {
+        try_each(&self.sources, "fetch_transfers", |s| async move {
+            s.fetch_transfers(block_num).await
+        })
+        .await
+    }
+
+    async fn fetch_tx_by_hash(&self, tx_hash: &str) -> Result<Option<Transaction>> {
+        try_each(&self.sources, "fetch_tx_by_hash", |s| {
+            let h = tx_hash.to_string();
+            async move { s.fetch_tx_by_hash(&h).await }
+        })
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Minimal mock source for testing failover behaviour. Each method
+    /// returns `Err(canned)` on the first `failures_remaining` calls then
+    /// `Ok(default)` thereafter.
+    struct MockSource {
+        name: &'static str,
+        latest_block_responses: Mutex<Vec<Result<u64>>>,
+    }
+
+    impl MockSource {
+        fn new(name: &'static str, responses: Vec<Result<u64>>) -> Self {
+            Self {
+                name,
+                latest_block_responses: Mutex::new(responses),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl BlockSource for MockSource {
+        fn name(&self) -> &'static str {
+            self.name
+        }
+        async fn latest_block(&self) -> Result<u64> {
+            let mut q = self.latest_block_responses.lock().unwrap();
+            if q.is_empty() {
+                return Err(eyre!("mock {}: exhausted responses", self.name));
+            }
+            q.remove(0)
+        }
+        async fn fetch_block(&self, _: u64) -> Result<Vec<Transaction>> {
+            unimplemented!()
+        }
+        async fn fetch_traces(&self, _: u64) -> Result<Vec<Trace>> {
+            unimplemented!()
+        }
+        async fn fetch_transfers(&self, _: u64) -> Result<Vec<Transfer>> {
+            unimplemented!()
+        }
+        async fn fetch_tx_by_hash(&self, _: &str) -> Result<Option<Transaction>> {
+            unimplemented!()
+        }
+    }
+
+    #[test]
+    fn is_recoverable_classifies_429() {
+        let e = eyre!("HTTP 429 too many requests");
+        assert!(is_recoverable(&e));
+    }
+
+    #[test]
+    fn is_recoverable_classifies_5xx() {
+        let e = eyre!("HTTP 502 Bad Gateway");
+        assert!(is_recoverable(&e));
+    }
+
+    #[test]
+    fn is_recoverable_classifies_timeout() {
+        let e = eyre!("operation timed out");
+        assert!(is_recoverable(&e));
+    }
+
+    #[test]
+    fn is_recoverable_rejects_auth() {
+        let e = eyre!("HTTP 401 Unauthorized: invalid api key");
+        assert!(!is_recoverable(&e));
+    }
+
+    #[test]
+    fn is_recoverable_rejects_parse() {
+        let e = eyre!("missing result field for eth_blockNumber");
+        assert!(!is_recoverable(&e));
+    }
+
+    #[test]
+    fn new_rejects_empty() {
+        assert!(FailoverSource::new(vec![]).is_err());
+    }
+
+    #[tokio::test]
+    async fn first_source_success_returns_immediately() {
+        let primary = Arc::new(MockSource::new("primary", vec![Ok(100)]));
+        let secondary = Arc::new(MockSource::new("secondary", vec![Ok(999)]));
+        let f = FailoverSource::new(vec![primary, secondary]).unwrap();
+        assert_eq!(f.latest_block().await.unwrap(), 100);
+    }
+
+    #[tokio::test]
+    async fn falls_back_on_recoverable_error() {
+        let primary = Arc::new(MockSource::new(
+            "primary",
+            vec![Err(eyre!("HTTP 429 rate limit"))],
+        ));
+        let secondary = Arc::new(MockSource::new("secondary", vec![Ok(200)]));
+        let f = FailoverSource::new(vec![primary, secondary]).unwrap();
+        assert_eq!(f.latest_block().await.unwrap(), 200);
+    }
+
+    #[tokio::test]
+    async fn stops_on_hard_error() {
+        let primary = Arc::new(MockSource::new(
+            "primary",
+            vec![Err(eyre!("HTTP 401 Unauthorized"))],
+        ));
+        let secondary = Arc::new(MockSource::new("secondary", vec![Ok(200)]));
+        let f = FailoverSource::new(vec![primary, secondary]).unwrap();
+        let err = f.latest_block().await.unwrap_err();
+        let msg = format!("{:#}", err);
+        assert!(msg.contains("non-recoverable"), "got: {}", msg);
+    }
+
+    #[tokio::test]
+    async fn all_recoverable_errors_exhausts_with_last() {
+        let primary = Arc::new(MockSource::new("primary", vec![Err(eyre!("HTTP 429"))]));
+        let secondary = Arc::new(MockSource::new(
+            "secondary",
+            vec![Err(eyre!("connection refused"))],
+        ));
+        let f = FailoverSource::new(vec![primary, secondary]).unwrap();
+        let err = f.latest_block().await.unwrap_err();
+        let msg = format!("{:#}", err);
+        assert!(msg.contains("all sources exhausted"), "got: {}", msg);
+    }
+}

--- a/etl-rs/crates/etl/src/sources/mod.rs
+++ b/etl-rs/crates/etl/src/sources/mod.rs
@@ -4,6 +4,7 @@ pub mod etherscan;
 pub mod failover;
 pub mod mock;
 pub mod public_rpc;
+pub mod rate_limiter;
 
 pub use block_source::{make_source, BlockSource, SourceConfig};
 pub use failover::FailoverSource;

--- a/etl-rs/crates/etl/src/sources/mod.rs
+++ b/etl-rs/crates/etl/src/sources/mod.rs
@@ -1,6 +1,10 @@
 pub mod alchemy;
 pub mod block_source;
 pub mod etherscan;
+pub mod failover;
 pub mod mock;
+pub mod public_rpc;
 
 pub use block_source::{make_source, BlockSource, SourceConfig};
+pub use failover::FailoverSource;
+pub use public_rpc::{PublicRpcSource, DEFAULT_PUBLIC_RPC_URL};

--- a/etl-rs/crates/etl/src/sources/public_rpc.rs
+++ b/etl-rs/crates/etl/src/sources/public_rpc.rs
@@ -1,0 +1,79 @@
+//! Public, no-API-key JSON-RPC [`BlockSource`]. Designed as the last-resort
+//! tier in [`super::failover::FailoverSource`]: when both Etherscan and
+//! Alchemy are rate-limited or unhealthy, fall through to a free public
+//! endpoint (Ankr, Cloudflare, Llamarpc, ...) so the worker can still make
+//! forward progress, albeit on a tighter shared budget.
+//!
+//! Implementation is a thin shell around the alchemy submodules, which are
+//! already provider-agnostic — they speak the standard Ethereum JSON-RPC
+//! surface plus Parity-style `trace_block`. Only the URL differs (no API
+//! key path segment) and the source name (`"public_rpc"` for metrics).
+
+use async_trait::async_trait;
+use eyre::Result;
+use reqwest::Client;
+use std::time::Duration;
+
+use super::alchemy;
+use super::block_source::BlockSource;
+use crate::types::{Trace, Transaction, Transfer};
+
+/// Default public RPC endpoint when `PUBLIC_RPC_URL` is unset. Ankr's
+/// open multichain endpoint requires no auth and supports `trace_block` on
+/// mainnet; it's rate-limited (~1500 req/day per IP) which is fine as a
+/// last-resort tier behind paid providers.
+pub const DEFAULT_PUBLIC_RPC_URL: &str = "https://rpc.ankr.com/eth";
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+pub struct PublicRpcSource {
+    client: Client,
+    url: String,
+}
+
+impl PublicRpcSource {
+    pub fn new(url: String) -> Self {
+        let client = Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .expect("build reqwest client");
+        Self { client, url }
+    }
+}
+
+#[async_trait]
+impl BlockSource for PublicRpcSource {
+    fn name(&self) -> &'static str {
+        "public_rpc"
+    }
+
+    async fn latest_block(&self) -> Result<u64> {
+        alchemy::block::eth_block_number(&self.client, &self.url).await
+    }
+
+    async fn fetch_block(&self, block_num: u64) -> Result<Vec<Transaction>> {
+        let mut txs =
+            alchemy::block::eth_get_block_by_number(&self.client, &self.url, block_num).await?;
+        // Receipt enrichment is best-effort; many public endpoints throttle
+        // batch receipt RPCs even when block fetches succeed.
+        if let Err(e) =
+            alchemy::receipts::enrich_with_receipts(&self.client, &self.url, block_num, &mut txs)
+                .await
+        {
+            tracing::warn!(block = block_num, source = "public_rpc", error = %e, "receipt enrichment failed");
+        }
+        Ok(txs)
+    }
+
+    async fn fetch_traces(&self, block_num: u64) -> Result<Vec<Trace>> {
+        alchemy::traces::trace_block(&self.client, &self.url, block_num).await
+    }
+
+    async fn fetch_transfers(&self, block_num: u64) -> Result<Vec<Transfer>> {
+        alchemy::logs::fetch_transfers(&self.client, &self.url, block_num).await
+    }
+
+    async fn fetch_tx_by_hash(&self, tx_hash: &str) -> Result<Option<Transaction>> {
+        alchemy::block::eth_get_transaction_by_hash(&self.client, &self.url, tx_hash).await
+    }
+}

--- a/etl-rs/crates/etl/src/sources/public_rpc.rs
+++ b/etl-rs/crates/etl/src/sources/public_rpc.rs
@@ -41,39 +41,51 @@ impl PublicRpcSource {
     }
 }
 
+/// Tag for the rate-limiter bucket. The shared alchemy submodules accept
+/// `provider` so this source draws from its own `public_rpc` budget, not
+/// alchemy's, even though they share JSON-RPC machinery.
+const PROVIDER: &str = "public_rpc";
+
 #[async_trait]
 impl BlockSource for PublicRpcSource {
     fn name(&self) -> &'static str {
-        "public_rpc"
+        PROVIDER
     }
 
     async fn latest_block(&self) -> Result<u64> {
-        alchemy::block::eth_block_number(&self.client, &self.url).await
+        alchemy::block::eth_block_number(PROVIDER, &self.client, &self.url).await
     }
 
     async fn fetch_block(&self, block_num: u64) -> Result<Vec<Transaction>> {
         let mut txs =
-            alchemy::block::eth_get_block_by_number(&self.client, &self.url, block_num).await?;
+            alchemy::block::eth_get_block_by_number(PROVIDER, &self.client, &self.url, block_num)
+                .await?;
         // Receipt enrichment is best-effort; many public endpoints throttle
         // batch receipt RPCs even when block fetches succeed.
-        if let Err(e) =
-            alchemy::receipts::enrich_with_receipts(&self.client, &self.url, block_num, &mut txs)
-                .await
+        if let Err(e) = alchemy::receipts::enrich_with_receipts(
+            PROVIDER,
+            &self.client,
+            &self.url,
+            block_num,
+            &mut txs,
+        )
+        .await
         {
-            tracing::warn!(block = block_num, source = "public_rpc", error = %e, "receipt enrichment failed");
+            tracing::warn!(block = block_num, source = PROVIDER, error = %e, "receipt enrichment failed");
         }
         Ok(txs)
     }
 
     async fn fetch_traces(&self, block_num: u64) -> Result<Vec<Trace>> {
-        alchemy::traces::trace_block(&self.client, &self.url, block_num).await
+        alchemy::traces::trace_block(PROVIDER, &self.client, &self.url, block_num).await
     }
 
     async fn fetch_transfers(&self, block_num: u64) -> Result<Vec<Transfer>> {
-        alchemy::logs::fetch_transfers(&self.client, &self.url, block_num).await
+        alchemy::logs::fetch_transfers(PROVIDER, &self.client, &self.url, block_num).await
     }
 
     async fn fetch_tx_by_hash(&self, tx_hash: &str) -> Result<Option<Transaction>> {
-        alchemy::block::eth_get_transaction_by_hash(&self.client, &self.url, tx_hash).await
+        alchemy::block::eth_get_transaction_by_hash(PROVIDER, &self.client, &self.url, tx_hash)
+            .await
     }
 }

--- a/etl-rs/crates/etl/src/sources/rate_limiter.rs
+++ b/etl-rs/crates/etl/src/sources/rate_limiter.rs
@@ -1,0 +1,248 @@
+//! Cross-replica rate limiter backed by Redis fixed-window counters.
+//!
+//! Issue #3 acceptance: the Etherscan free tier is ~5 req/s, and naively
+//! scaling `worker` to N replicas would multiply our 429s instead of
+//! throughput. This module gives each provider (Etherscan / Alchemy /
+//! public RPC) a single Redis-backed counter — all replicas drain the
+//! same per-second budget atomically via Redis `INCR`.
+//!
+//! ## Why fixed window, not strict token bucket?
+//!
+//! Pure Rust + no Lua / no module rules out an atomic check-and-decrement
+//! on the Redis side. INCR is the only atomic primitive we get. Fixed
+//! window — one counter per wall-clock second, TTL'd after two seconds —
+//! is the simplest design that:
+//!   1. coordinates correctly across replicas (single Redis ops, no race)
+//!   2. survives Redis flakiness (if Redis is down we proceed without
+//!      throttling rather than wedging)
+//!   3. needs no server-side state machine
+//!
+//! Tradeoff: at window boundaries you can get up to 2x the configured
+//! rate in burst (5 req at 99.999s plus 5 req at 100.001s). For
+//! Etherscan-class budgets (5 req/s) this is well within the provider's
+//! tolerance — the 1s windows are an order of magnitude finer than their
+//! enforcement granularity.
+//!
+//! ## Wiring
+//!
+//! - `init_limiters(redis_url)` is called once at worker / ingest startup.
+//!   It reads `<PROVIDER>_RATE_LIMIT_PER_SEC` env vars and installs one
+//!   limiter per provider; unset → no limiter (HTTP unconstrained).
+//! - Every HTTP call site in `sources::etherscan / alchemy / public_rpc`
+//!   calls [`acquire`] with its provider name before sending. If a limiter
+//!   exists, the call blocks until the current 1s window has budget;
+//!   otherwise it's a no-op.
+
+use eyre::{Result, WrapErr};
+use redis::aio::ConnectionManager;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::sync::OnceCell;
+use tracing::{debug, info, warn};
+
+/// Upper bound on how long [`RedisRateLimiter::acquire`] will sleep on a
+/// single over-budget result. Caps tail latency on pathological config
+/// (e.g. clock skew that puts `now` far behind Redis).
+const MAX_BACKOFF_MS: u64 = 1_000;
+
+/// TTL applied to per-second counter keys. Two seconds so an in-flight
+/// INCR right at a window boundary still finds its key alive on read.
+const COUNTER_TTL_SECS: u64 = 2;
+
+/// One per-provider limiter. Holds its own clone of the connection
+/// manager — cloning is cheap because `ConnectionManager` is internally
+/// `Arc`-shared.
+pub struct RedisRateLimiter {
+    redis: ConnectionManager,
+    key_prefix: String,
+    capacity_per_sec: u32,
+    provider: &'static str,
+}
+
+impl RedisRateLimiter {
+    pub fn new(
+        redis: ConnectionManager,
+        provider: &'static str,
+        capacity_per_sec: u32,
+    ) -> Self {
+        Self {
+            redis,
+            key_prefix: format!("ratelimit:{}", provider),
+            capacity_per_sec,
+            provider,
+        }
+    }
+
+    /// Block until we have headroom in the current 1s window.
+    ///
+    /// Algorithm: bucket key = `ratelimit:<provider>:<unix_second>`.
+    /// `INCR` the key — atomic. If the resulting count is the first one,
+    /// also `EXPIRE` it so the key garbage-collects. If the count exceeds
+    /// the per-second budget, sleep until the next second and retry.
+    /// On Redis errors, log and proceed unthrottled — better to risk a
+    /// single 429 than to wedge the worker.
+    pub async fn acquire(&self) -> Result<()> {
+        let mut conn = self.redis.clone();
+        loop {
+            let now_ms = now_unix_ms();
+            let now_sec = now_ms / 1000;
+            let key = format!("{}:{}", self.key_prefix, now_sec);
+
+            let incr_res: redis::RedisResult<i64> = redis::cmd("INCR")
+                .arg(&key)
+                .query_async(&mut conn)
+                .await;
+
+            let count = match incr_res {
+                Ok(c) => c,
+                Err(e) => {
+                    warn!(
+                        provider = self.provider,
+                        error = %e,
+                        "rate limiter: Redis INCR failed, proceeding without throttle"
+                    );
+                    return Ok(());
+                }
+            };
+
+            // First write in this window: bound the key's lifetime so it
+            // doesn't leak forever. Best-effort — if EXPIRE fails the
+                // worst case is one stale key that costs a few bytes.
+            if count == 1 {
+                let _: redis::RedisResult<()> = redis::cmd("EXPIRE")
+                    .arg(&key)
+                    .arg(COUNTER_TTL_SECS)
+                    .query_async(&mut conn)
+                    .await;
+            }
+
+            if count <= self.capacity_per_sec as i64 {
+                return Ok(());
+            }
+
+            // Over budget — sleep just past the next second boundary so
+            // we line up with the next window's fresh counter.
+            let ms_to_next_sec = 1000 - (now_ms % 1000) + 1;
+            let sleep_ms = ms_to_next_sec.min(MAX_BACKOFF_MS);
+            debug!(
+                provider = self.provider,
+                count,
+                cap = self.capacity_per_sec,
+                sleep_ms,
+                "rate limiter: window full, sleeping to next window"
+            );
+            tokio::time::sleep(Duration::from_millis(sleep_ms)).await;
+        }
+    }
+}
+
+fn now_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Process-global limiter registry. Set once by [`init_limiters`] at
+/// startup; subsequent `acquire` calls look up by provider name.
+static LIMITERS: OnceCell<HashMap<&'static str, Arc<RedisRateLimiter>>> = OnceCell::const_new();
+
+/// Install limiters for every provider that has `<PROVIDER>_RATE_LIMIT_PER_SEC`
+/// set in env. Worker / ingest startup paths call this exactly once;
+/// re-init is rejected.
+///
+/// Env vars consulted:
+///   - `ETHERSCAN_RATE_LIMIT_PER_SEC`
+///   - `ALCHEMY_RATE_LIMIT_PER_SEC`
+///   - `PUBLIC_RPC_RATE_LIMIT_PER_SEC`
+///
+/// Each is the integer cap on requests per second for that provider
+/// across the entire worker fleet.
+pub async fn init_limiters(redis_url: &str) -> Result<()> {
+    let client = redis::Client::open(redis_url)
+        .wrap_err("rate limiter: opening Redis client")?;
+    let conn = ConnectionManager::new(client)
+        .await
+        .wrap_err("rate limiter: connecting to Redis")?;
+
+    let mut map: HashMap<&'static str, Arc<RedisRateLimiter>> = HashMap::new();
+    let mut configured: Vec<(&'static str, u32)> = Vec::new();
+
+    for &provider in &["etherscan", "alchemy", "public_rpc"] {
+        if let Some(per_sec) = read_provider_rate(provider) {
+            let limiter = RedisRateLimiter::new(conn.clone(), provider, per_sec);
+            map.insert(provider, Arc::new(limiter));
+            configured.push((provider, per_sec));
+        }
+    }
+
+    LIMITERS
+        .set(map)
+        .map_err(|_| eyre::eyre!("rate limiters already initialised"))?;
+
+    if configured.is_empty() {
+        info!("rate limiter: no <PROVIDER>_RATE_LIMIT_PER_SEC set, all sources unthrottled");
+    } else {
+        for (provider, per_sec) in configured {
+            info!(provider, per_sec, "rate limiter: configured");
+        }
+    }
+    Ok(())
+}
+
+fn read_provider_rate(provider: &str) -> Option<u32> {
+    let upper = provider.to_ascii_uppercase();
+    std::env::var(format!("{}_RATE_LIMIT_PER_SEC", upper))
+        .ok()
+        .and_then(|v| v.parse::<u32>().ok())
+        .filter(|n| *n > 0)
+}
+
+/// Wait for budget in the current window for `provider`. If no limiter
+/// is configured, returns immediately — call sites can blindly
+/// `await rate_limiter::acquire("etherscan")` without checking whether
+/// the env is set.
+pub async fn acquire(provider: &'static str) {
+    let Some(map) = LIMITERS.get() else { return };
+    let Some(limiter) = map.get(provider) else {
+        return;
+    };
+    let _ = limiter.acquire().await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_provider_rate_returns_none_when_unset() {
+        assert!(read_provider_rate("NEVERSET").is_none());
+    }
+
+    #[test]
+    fn read_provider_rate_parses_positive() {
+        std::env::set_var("UNITTEST_PROV_RATE_LIMIT_PER_SEC", "5");
+        assert_eq!(read_provider_rate("UNITTEST_PROV"), Some(5));
+        std::env::remove_var("UNITTEST_PROV_RATE_LIMIT_PER_SEC");
+    }
+
+    #[test]
+    fn read_provider_rate_rejects_zero_or_garbage() {
+        std::env::set_var("UNITTEST_PROV_ZERO_RATE_LIMIT_PER_SEC", "0");
+        assert_eq!(read_provider_rate("UNITTEST_PROV_ZERO"), None);
+        std::env::remove_var("UNITTEST_PROV_ZERO_RATE_LIMIT_PER_SEC");
+
+        std::env::set_var("UNITTEST_PROV_GARBAGE_RATE_LIMIT_PER_SEC", "abc");
+        assert_eq!(read_provider_rate("UNITTEST_PROV_GARBAGE"), None);
+        std::env::remove_var("UNITTEST_PROV_GARBAGE_RATE_LIMIT_PER_SEC");
+    }
+
+    #[tokio::test]
+    async fn acquire_is_noop_when_uninitialised() {
+        // The OnceCell may be set in earlier tests, so we can't assert
+        // unconditional no-op — but acquire must never panic or hang
+        // for an unconfigured provider regardless.
+        acquire("provider_that_does_not_exist_anywhere").await;
+    }
+}

--- a/etl-rs/crates/etl/src/sources/rate_limiter.rs
+++ b/etl-rs/crates/etl/src/sources/rate_limiter.rs
@@ -1,6 +1,6 @@
 //! Cross-replica rate limiter backed by Redis fixed-window counters.
 //!
-//! Issue #3 acceptance: the Etherscan free tier is ~5 req/s, and naively
+//! Issue #27 acceptance: the Etherscan free tier is ~5 req/s, and naively
 //! scaling `worker` to N replicas would multiply our 429s instead of
 //! throughput. This module gives each provider (Etherscan / Alchemy /
 //! public RPC) a single Redis-backed counter — all replicas drain the

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -11,7 +11,7 @@ overlay (managed K8s + managed databases) is a follow-up — see the
 k8s/
 ├── namespace.yaml            # Namespace: chain-analysis
 ├── secret.example.yaml       # TEMPLATE — shared Secret across all components
-├── worker/                   # Rust worker (3 replicas, Issue #3)
+├── worker/                   # Rust worker (3 replicas, Issue #27)
 │   ├── configmap.yaml
 │   └── deployment.yaml
 ├── infra/                    # Stateful tier (StatefulSet + PVC)
@@ -105,7 +105,7 @@ kubectl -n chain-analysis exec -it deployment/backend -- /bin/sh
 kubectl delete namespace chain-analysis
 ```
 
-## What transfers from Issue #3 unchanged
+## What transfers from Issue #27 unchanged
 
 The worker's multi-replica safety relies entirely on Redis-side
 coordination, which is orchestrator-agnostic:

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,147 @@
+# Kubernetes manifests
+
+Dev-targeted manifests for the full chain-analysis stack. Single-node
+cluster assumed (kind / minikube / Docker Desktop K8s). Production
+overlay (managed K8s + managed databases) is a follow-up — see the
+"prod migration" notes at the bottom.
+
+## Layout
+
+```
+k8s/
+├── namespace.yaml            # Namespace: chain-analysis
+├── secret.example.yaml       # TEMPLATE — shared Secret across all components
+├── worker/                   # Rust worker (3 replicas, Issue #3)
+│   ├── configmap.yaml
+│   └── deployment.yaml
+├── infra/                    # Stateful tier (StatefulSet + PVC)
+│   ├── redis.yaml
+│   ├── postgres.yaml
+│   └── neo4j.yaml
+└── app/                      # Application tier
+    ├── backend.yaml          # FastAPI (single replica — entrypoint runs migrations)
+    └── frontend.yaml         # Vite dev server
+```
+
+What's left as compose for now (not part of this migration):
+- ClickHouse (not active in worker path)
+- Dagster (dormant per CLAUDE.md)
+- Prometheus / Grafana (observability — separate follow-up)
+
+## Bring it up
+
+```bash
+# 1) Make sure your local K8s cluster is running and `kubectl` points at it.
+kubectl cluster-info
+
+# 2) Build the local images. K8s does not build — you build, then load.
+docker build -f backend/Dockerfile  -t chain-analysis/backend:local .
+docker build -f frontend/Dockerfile --target development \
+                                     -t chain-analysis/frontend:local frontend
+docker build -f etl-rs/Dockerfile  --target worker \
+                                     -t chain-analysis/worker:local etl-rs
+
+# Load images into the cluster (pick the one matching your local K8s):
+#   kind:                kind load docker-image chain-analysis/{backend,frontend,worker}:local
+#   minikube:            minikube image load chain-analysis/{backend,frontend,worker}:local
+#   Docker Desktop K8s:  images on the host are already visible to the cluster.
+
+# 3) Create the namespace and the shared Secret. The Secret is NOT applied
+#    from secret.example.yaml — that file is a template documenting the
+#    expected keys. Create the real Secret with `kubectl create secret`:
+kubectl apply -f k8s/namespace.yaml
+
+kubectl -n chain-analysis create secret generic chain-analysis-secrets \
+  --from-literal=NEO4J_PASSWORD=changeme \
+  --from-literal=POSTGRES_PASSWORD=changeme \
+  --from-literal=DATABASE_URL=postgresql://postgres:changeme@postgres:5432/chain_analysis \
+  --from-literal=JWT_SECRET_KEY=changeme \
+  --from-literal=ETHERSCAN_API_KEY=YOUR_KEY_HERE \
+  --from-literal=ALCHEMY_API_KEY=
+
+# 4) Apply infra first (worker / backend depend on these being up).
+kubectl apply -f k8s/infra/
+
+# Wait for the stateful tier to be Ready before continuing — pg_isready /
+# Neo4j HTTP probes have to pass.
+kubectl -n chain-analysis rollout status statefulset/redis
+kubectl -n chain-analysis rollout status statefulset/postgres
+kubectl -n chain-analysis rollout status statefulset/neo4j
+
+# 5) Apply backend (runs alembic + seeds on startup), then worker, then frontend.
+kubectl apply -f k8s/app/backend.yaml
+kubectl -n chain-analysis rollout status deployment/backend
+
+kubectl apply -f k8s/worker/
+kubectl apply -f k8s/app/frontend.yaml
+```
+
+## Access from your host
+
+No Ingress in dev — use port-forward:
+
+```bash
+kubectl -n chain-analysis port-forward svc/backend  8000:8000   # http://localhost:8000
+kubectl -n chain-analysis port-forward svc/frontend 5173:5173   # http://localhost:5173
+kubectl -n chain-analysis port-forward svc/neo4j    7474:7474   # Neo4j browser
+```
+
+## Common operations
+
+```bash
+# All pods at a glance
+kubectl -n chain-analysis get pods
+
+# Worker logs from all 3 replicas, live
+kubectl -n chain-analysis logs -f -l app=worker --max-log-requests=3 --tail=20
+
+# Scale worker
+kubectl -n chain-analysis scale deployment/worker --replicas=5
+
+# Shell into a pod
+kubectl -n chain-analysis exec -it deployment/backend -- /bin/sh
+
+# Tear everything down
+kubectl delete namespace chain-analysis
+```
+
+## What transfers from Issue #3 unchanged
+
+The worker's multi-replica safety relies entirely on Redis-side
+coordination, which is orchestrator-agnostic:
+
+| Worker behaviour | Mechanism | K8s impact |
+|---|---|---|
+| Task A safely shares the targeted queue | Redis `BRPOP` atomic dispatch | None — works as-is |
+| Task B only one replica refreshes per tick | Redis `SET refresh_lease NX EX` | None |
+| Task C multi-consumer stream consumption | Redis consumer groups | None |
+| Per-replica identity (lease owner id) | `replica_id()` reads `$HOSTNAME` | K8s sets each pod's hostname to its pod name (unique), so this just works |
+| Cross-replica rate limiter | Redis fixed-window `INCR`+`EXPIRE` | None |
+
+Worker source code is byte-identical between the compose and K8s
+deployments — only `compose/etl.yml` vs `k8s/worker/deployment.yaml`
+differ.
+
+## Prod migration follow-ups (out of scope here)
+
+These need decisions before the manifests can target prod:
+
+1. **Cluster.** Managed (GKE / EKS / AKS) vs self-hosted (k3s / kubeadm).
+   Affects ingress controller choice and PV storage class.
+2. **Databases.** Run Postgres / Neo4j in-cluster (current manifests)
+   vs managed services (Cloud SQL / AuraDB). In-cluster databases need a
+   backup story (per roadmap Issue #8); managed services solve that for
+   money.
+3. **Image registry.** `imagePullPolicy: IfNotPresent` + local image
+   loading works for single-node dev; multi-node prod needs images
+   pushed to a registry (GHCR / ECR / Artifact Registry) and a
+   `kubernetes.io/dockerconfigjson` Secret for pull auth.
+4. **Ingress.** Frontend and backend currently only reachable via
+   `port-forward`. For prod, add an `Ingress` resource per service plus
+   an ingress controller (nginx-ingress / Traefik / managed).
+5. **Secrets.** Out-of-band `kubectl create secret` is fine for dev.
+   Prod should use sealed-secrets, External Secrets Operator, or the
+   managed K8s integration with cloud secret managers.
+6. **HPA.** Worker `replicas: 3` is fixed. Add a `HorizontalPodAutoscaler`
+   targeting queue depth or CPU once a metric source is wired
+   (Prometheus Adapter or KEDA).

--- a/k8s/app/backend.yaml
+++ b/k8s/app/backend.yaml
@@ -1,0 +1,86 @@
+# FastAPI backend. backend/entrypoint.sh runs alembic migrations + seeds
+# on every container start, then `uvicorn`. Single replica avoids racing
+# the migrations against itself — for HA, extract migrations into an
+# initContainer or a one-shot Job and only then scale replicas.
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  namespace: chain-analysis
+spec:
+  type: ClusterIP
+  selector:
+    app: backend
+  ports:
+    - port: 8000
+      targetPort: 8000
+      name: http
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backend-config
+  namespace: chain-analysis
+data:
+  ENVIRONMENT: "local"
+  NEO4J_URI: "bolt://neo4j:7687"
+  NEO4J_USER: "neo4j"
+  POSTGRES_HOST: "postgres"
+  POSTGRES_PORT: "5432"
+  POSTGRES_DB: "chain_analysis"
+  POSTGRES_USER: "postgres"
+  REDIS_URL: "redis://redis:6379"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: chain-analysis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      labels:
+        app: backend
+    spec:
+      containers:
+        - name: backend
+          # Build locally: docker build -f backend/Dockerfile -t chain-analysis/backend:local .
+          # Then load into the local cluster (kind / minikube / Docker Desktop).
+          # A real multi-node cluster needs this pushed to a registry.
+          image: chain-analysis/backend:local
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - configMapRef:
+                name: backend-config
+            - secretRef:
+                name: chain-analysis-secrets
+          ports:
+            - containerPort: 8000
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 12
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "256Mi"
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+# To reach the backend from your host (no Ingress in dev):
+#   kubectl -n chain-analysis port-forward svc/backend 8000:8000
+# then hit http://localhost:8000/health

--- a/k8s/app/frontend.yaml
+++ b/k8s/app/frontend.yaml
@@ -1,0 +1,79 @@
+# Vite frontend dev server. The compose version bind-mounted ./src into
+# the container for hot reload; that doesn't translate cleanly to K8s
+# (no host filesystem on the cluster). For dev iteration, rebuild the
+# image when source changes, or use Tilt/Skaffold for live sync.
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: chain-analysis
+spec:
+  type: ClusterIP
+  selector:
+    app: frontend
+  ports:
+    - port: 5173
+      targetPort: 5173
+      name: http
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frontend-config
+  namespace: chain-analysis
+data:
+  # Vite reads this at server startup and uses it as the /api proxy
+  # target, so the frontend talks to backend via in-cluster DNS.
+  VITE_API_PROXY_TARGET: "http://backend:8000"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: chain-analysis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+        - name: frontend
+          # Build locally: docker build -f frontend/Dockerfile --target development \
+          #   -t chain-analysis/frontend:local frontend
+          # Then load into the local cluster (see backend / worker notes).
+          image: chain-analysis/frontend:local
+          imagePullPolicy: IfNotPresent
+          command: ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
+          envFrom:
+            - configMapRef:
+                name: frontend-config
+          ports:
+            - containerPort: 5173
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+# To reach the frontend from your host:
+#   kubectl -n chain-analysis port-forward svc/frontend 5173:5173
+# then open http://localhost:5173

--- a/k8s/dev/kind-multinode.yaml
+++ b/k8s/dev/kind-multinode.yaml
@@ -1,0 +1,15 @@
+# Local multi-node "cross-machine" simulation. kind spins up each "node"
+# as a Docker container with containerd inside; pods then get scheduled
+# across those fake nodes exactly like a real multi-machine cluster.
+#
+# Bring up:
+#   kind create cluster --name chain-analysis --config k8s/dev/kind-multinode.yaml
+#
+# Tear down:
+#   kind delete cluster --name chain-analysis
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+  - role: worker
+  - role: worker

--- a/k8s/infra/neo4j.yaml
+++ b/k8s/infra/neo4j.yaml
@@ -1,0 +1,128 @@
+# Neo4j 5.x Enterprise + GDS plugin (used by AML detection Cypher in
+# backend/src/graph/queries.py). Single replica for dev; clustering
+# would need StatefulSet replicas + core/replica role config + an
+# Enterprise license that covers cluster mode.
+#
+# Single Service exposing both HTTP (7474, browser UI / readiness) and
+# Bolt (7687, driver protocol used by backend & worker).
+apiVersion: v1
+kind: Service
+metadata:
+  name: neo4j
+  namespace: chain-analysis
+spec:
+  clusterIP: None
+  selector:
+    app: neo4j
+  ports:
+    - name: http
+      port: 7474
+      targetPort: 7474
+    - name: bolt
+      port: 7687
+      targetPort: 7687
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: neo4j-config
+  namespace: chain-analysis
+data:
+  NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"
+  NEO4J_PLUGINS: '["graph-data-science"]'
+  NEO4J_dbms_memory_heap_initial__size: "512m"
+  NEO4J_dbms_memory_heap_max__size: "2G"
+  NEO4J_dbms_memory_pagecache_size: "512m"
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: neo4j
+  namespace: chain-analysis
+spec:
+  serviceName: neo4j
+  replicas: 1
+  selector:
+    matchLabels:
+      app: neo4j
+  template:
+    metadata:
+      labels:
+        app: neo4j
+    spec:
+      containers:
+        - name: neo4j
+          image: neo4j:5.26.0-enterprise
+          envFrom:
+            - configMapRef:
+                name: neo4j-config
+          env:
+            # K8s env-var substitution: `$(VAR)` in a value resolves to a
+            # previously-defined env var in the same list. We pull the
+            # password from the Secret into a NON-`NEO4J_`-prefixed var
+            # first (the image treats any `NEO4J_*` env as a config
+            # setting and rejects unknown ones), then compose NEO4J_AUTH
+            # ("neo4j/<password>") which is the format the image expects.
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: chain-analysis-secrets
+                  key: NEO4J_PASSWORD
+            - name: NEO4J_AUTH
+              value: "neo4j/$(DB_PASSWORD)"
+          ports:
+            - containerPort: 7474
+              name: http
+            - containerPort: 7687
+              name: bolt
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 90
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "3Gi"
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: logs
+              mountPath: /logs
+            - name: plugins
+              mountPath: /plugins
+  # Three PVCs match the compose volumes (neo4j_data / logs / plugins).
+  # `plugins` is small but separate so GDS jar survives data wipes.
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 20Gi
+    - metadata:
+        name: logs
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 2Gi
+    - metadata:
+        name: plugins
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi

--- a/k8s/infra/postgres.yaml
+++ b/k8s/infra/postgres.yaml
@@ -1,0 +1,88 @@
+# PostgreSQL — entity_features, ingestion_runs, raw_transactions,
+# known_labels, label_tasks, annotations, users. Single replica for dev;
+# HA in prod typically uses a managed Postgres (Cloud SQL / RDS / Aurora)
+# rather than running stateful Postgres in K8s.
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: chain-analysis
+spec:
+  clusterIP: None
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432
+      name: postgres
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-config
+  namespace: chain-analysis
+data:
+  POSTGRES_USER: "postgres"
+  POSTGRES_DB: "chain_analysis"
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: chain-analysis
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:17-alpine
+          envFrom:
+            - configMapRef:
+                name: postgres-config
+          env:
+            # Password pulled from the shared Secret. On first start
+            # Postgres uses this to initialise the `postgres` superuser.
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: chain-analysis-secrets
+                  key: POSTGRES_PASSWORD
+          ports:
+            - containerPort: 5432
+              name: postgres
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "postgres"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "postgres"]
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 10Gi

--- a/k8s/infra/redis.yaml
+++ b/k8s/infra/redis.yaml
@@ -1,0 +1,73 @@
+# Redis — Streams + targeted-queue list + cross-replica coordination
+# (Task B refresh lease, rate-limiter counters). Single replica is
+# sufficient for dev; HA would use a Redis cluster / sentinel chart.
+#
+# Headless Service (clusterIP: None) gives stable per-pod DNS — necessary
+# for StatefulSets even with a single replica, and lets `redis-0.redis`
+# resolve directly.
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: chain-analysis
+spec:
+  clusterIP: None
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+      name: redis
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+  namespace: chain-analysis
+spec:
+  serviceName: redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          # AOF persistence keeps state through pod restarts. PVC below
+          # preserves it across pod rescheduling.
+          args: ["redis-server", "--appendonly", "yes"]
+          ports:
+            - containerPort: 6379
+              name: redis
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "1Gi"
+          volumeMounts:
+            - name: data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 5Gi

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,6 +1,7 @@
 # All chain-analysis resources live in one namespace so they can be
-# applied / torn down as a unit (`kubectl apply -k k8s/`,
-# `kubectl delete namespace chain-analysis`).
+# torn down as a unit (`kubectl delete namespace chain-analysis`).
+# Apply per-directory with `kubectl apply -f` — see k8s/README.md for
+# the ordered bring-up (infra first, then backend, worker, frontend).
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,7 @@
+# All chain-analysis resources live in one namespace so they can be
+# applied / torn down as a unit (`kubectl apply -k k8s/`,
+# `kubectl delete namespace chain-analysis`).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: chain-analysis

--- a/k8s/secret.example.yaml
+++ b/k8s/secret.example.yaml
@@ -1,0 +1,35 @@
+# TEMPLATE — do not commit a filled-in copy.
+#
+# Shared Secret consumed by every component that needs credentials,
+# mirroring how `compose/secrets.dev.env` is shared across services in
+# the docker compose stack.
+#
+# Create the real Secret out-of-band so credentials never land in git:
+#
+#   kubectl create secret generic chain-analysis-secrets \
+#     --namespace chain-analysis \
+#     --from-literal=NEO4J_PASSWORD=changeme \
+#     --from-literal=POSTGRES_PASSWORD=changeme \
+#     --from-literal=DATABASE_URL=postgresql://postgres:changeme@postgres:5432/chain_analysis \
+#     --from-literal=JWT_SECRET_KEY=changeme \
+#     --from-literal=ETHERSCAN_API_KEY= \
+#     --from-literal=ALCHEMY_API_KEY=
+#
+# Consumers:
+#   - worker    — NEO4J_PASSWORD, POSTGRES_PASSWORD, DATABASE_URL, *_API_KEY
+#   - backend   — same set + JWT_SECRET_KEY
+#   - postgres  — POSTGRES_PASSWORD (sets the `postgres` superuser password on first start)
+#   - neo4j     — NEO4J_PASSWORD (composed into NEO4J_AUTH via env substitution)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chain-analysis-secrets
+  namespace: chain-analysis
+type: Opaque
+stringData:
+  NEO4J_PASSWORD: "changeme"
+  POSTGRES_PASSWORD: "changeme"
+  DATABASE_URL: "postgresql://postgres:changeme@postgres:5432/chain_analysis"
+  JWT_SECRET_KEY: "changeme"
+  ETHERSCAN_API_KEY: ""
+  ALCHEMY_API_KEY: ""

--- a/k8s/worker/configmap.yaml
+++ b/k8s/worker/configmap.yaml
@@ -26,7 +26,7 @@ data:
   NEIGHBORHOOD_TX_LIMIT_PER_ADDR: "500"
   MAX_PEERS_PER_HOP: "20"
 
-  # Cross-replica rate limits (Issue #3). Unset a key to leave that
+  # Cross-replica rate limits (Issue #27). Unset a key to leave that
   # provider unthrottled.
   ETHERSCAN_RATE_LIMIT_PER_SEC: "5"
   ALCHEMY_RATE_LIMIT_PER_SEC: "100"

--- a/k8s/worker/configmap.yaml
+++ b/k8s/worker/configmap.yaml
@@ -1,0 +1,36 @@
+# Non-secret worker configuration. Mirrors the `environment:` block of the
+# worker service in compose/etl.yml. Secret values (passwords, API keys)
+# live in the Secret, not here.
+#
+# Service hostnames (redis / neo4j / postgres) resolve via Kubernetes DNS
+# to the Services of the same name in this namespace — same names as the
+# compose services, so connection strings are unchanged.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: worker-config
+  namespace: chain-analysis
+data:
+  REDIS_URL: "redis://redis:6379"
+  NEO4J_URI: "bolt://neo4j:7687"
+  NEO4J_USER: "neo4j"
+  NEO4J_DATABASE: "neo4j"
+
+  # Task B refresh loop
+  REFRESH_INTERVAL_SECS: "300"
+  REFRESH_COOLDOWN_SECS: "1800"
+  REFRESH_TX_LIMIT_PER_ADDR: "500"
+
+  # Task A targeted queue
+  TARGETED_BRPOP_TIMEOUT_SECS: "5"
+  NEIGHBORHOOD_TX_LIMIT_PER_ADDR: "500"
+  MAX_PEERS_PER_HOP: "20"
+
+  # Cross-replica rate limits (Issue #3). Unset a key to leave that
+  # provider unthrottled.
+  ETHERSCAN_RATE_LIMIT_PER_SEC: "5"
+  ALCHEMY_RATE_LIMIT_PER_SEC: "100"
+  PUBLIC_RPC_RATE_LIMIT_PER_SEC: "20"
+
+  # No LOG_DIR: in Kubernetes the worker logs to stdout only and
+  # `kubectl logs` is the access path. No host bind mount, no log volume.

--- a/k8s/worker/deployment.yaml
+++ b/k8s/worker/deployment.yaml
@@ -1,7 +1,7 @@
 # Worker Deployment — the Kubernetes equivalent of the compose `worker`
 # service with `deploy.replicas`.
 #
-# Why this maps cleanly from compose (Issue #3 groundwork):
+# Why this maps cleanly from compose (Issue #27 groundwork):
 #   - Task A (BRPOP queue)  — Redis dispatches each entry to one consumer;
 #     N pods sharing the queue is safe with no extra work.
 #   - Task B (refresh loop) — gated by a Redis lease (SET NX EX), so only

--- a/k8s/worker/deployment.yaml
+++ b/k8s/worker/deployment.yaml
@@ -1,0 +1,72 @@
+# Worker Deployment — the Kubernetes equivalent of the compose `worker`
+# service with `deploy.replicas`.
+#
+# Why this maps cleanly from compose (Issue #3 groundwork):
+#   - Task A (BRPOP queue)  — Redis dispatches each entry to one consumer;
+#     N pods sharing the queue is safe with no extra work.
+#   - Task B (refresh loop) — gated by a Redis lease (SET NX EX), so only
+#     one pod runs the refresh tick per interval.
+#   - Task C (XREADGROUP)   — Redis consumer groups are natively multi-
+#     consumer; each pod registers under a unique consumer name.
+#   - replica identity      — refresh.rs reads $HOSTNAME for the lease
+#     owner id; Kubernetes sets each pod's hostname to the pod name, which
+#     is unique, so this works unchanged.
+#
+# All cross-replica coordination is via Redis, not the orchestrator —
+# which is why the same worker image runs identically under compose or K8s.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  namespace: chain-analysis
+  labels:
+    app: worker
+spec:
+  # Equivalent of compose `deploy.replicas`. Scale with
+  # `kubectl scale deployment/worker --replicas=N` or edit here.
+  replicas: 3
+  selector:
+    matchLabels:
+      app: worker
+  template:
+    metadata:
+      labels:
+        app: worker
+    spec:
+      containers:
+        - name: worker
+          # Built locally for now: `docker build -f etl-rs/Dockerfile
+          # --target worker -t chain-analysis/worker:local etl-rs`, then
+          # load into the local cluster (kind: `kind load docker-image`,
+          # minikube: `minikube image load`). A real multi-node cluster
+          # needs this pushed to a registry — see the K8s migration issue.
+          image: chain-analysis/worker:local
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - configMapRef:
+                name: worker-config
+            - secretRef:
+                # Shared Secret defined at k8s/secret.example.yaml — same
+                # credentials power worker, backend, postgres, neo4j.
+                name: chain-analysis-secrets
+          ports:
+            # Prometheus metrics endpoint (observability.rs).
+            - name: metrics
+              containerPort: 9100
+          livenessProbe:
+            # The worker has no HTTP health route; a TCP check on the
+            # metrics port confirms the process is up and serving.
+            tcpSocket:
+              port: metrics
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+      # Worker is stateless (all state in Redis / PG / Neo4j); a pod can
+      # be killed and rescheduled freely. No volumes — logs go to stdout.
+      restartPolicy: Always


### PR DESCRIPTION
Closes #27 .

## Summary

Worker pipeline can now run N replicas safely; pluggable source tier falls back on rate-limit / 5xx; cross-replica rate limiter caps shared API budget; new histogram lets us measure deep-trace latency against the issue's p50/p95 target. K8s manifests added as the cross-machine deployment story (compose still works).

## Acceptance criteria

| Issue point | Commit | Notes |
|---|---|---|
| `worker` scales to N replicas via `deploy.replicas` in `compose/etl.yml`; Task B distributed lease via `SET NX EX` | `b2914ed` | Task A (BRPOP) was already multi-reader safe; Task C (XREADGROUP) was already multi-consumer via consumer group |
| `FailoverSource` over `BlockSource` with Etherscan → Alchemy → public RPC | `93f758a` | Recoverable errors (429 / 5xx / timeout) descend; hard errors (auth, parse) propagate. `PublicRpcSource` reuses Alchemy JSON-RPC plumbing, defaults to Ankr, needs no API key |
| Shared rate limiter via Redis | `89600b9` | Implemented as Redis fixed-window (`INCR` + `EXPIRE`) — pure Rust, no Lua, no `redis-cell` module. Per-provider budgets configurable via env |
| `finished_at - pickup_at` histogram + `pickup_at` column | `dc40180` | Prometheus histogram `label_task_duration_seconds{kind,outcome}` + Alembic migration `009_label_tasks_pickup_at` |

## K8s addendum

The issue's scope is "scale across worker replicas". Including K8s here because cross-machine deployment was the immediate follow-up question and the worker multi-replica safety only matters once you actually deploy across machines.

- `k8s/` — namespace, shared Secret template, worker Deployment, infra StatefulSets (Redis / Postgres / Neo4j), backend & frontend Deployments
- `k8s/dev/kind-multinode.yaml` — 1 control-plane + 2 worker kind cluster for verifying cross-node scheduling locally
- `k8s/README.md` — bring-up steps, port-forward instructions, prod migration follow-ups

Verified locally with kind:
- Pods distributed across `ca-k8s-worker` / `ca-k8s-worker2`
- `docker stop ca-k8s-worker2` → stateless Deployment pods rescheduled to surviving node immediately
- StatefulSet pods cannot reschedule (local PVC bound to dead node) — flagged as prod follow-up: use managed DB or RWX storage class

Worker source code is byte-identical between compose and K8s; only orchestrator manifests differ.

## Notable design choices

- **Pure-Rust rate limiter, not Lua / `redis-cell`.** Fixed-window `INCR` + 1-second `EXPIRE` is two commands per check, no module install, no scripting. Burst tolerance is slightly worse than token bucket but invisible at 5 req/s.
- **`SET NX EX (interval - 30)s` lease, not lock-with-renewal.** Task B is idempotent and runs every N seconds — letting the lease auto-expire is simpler than refreshing it from a heartbeat.

## Bug fixes pulled in

- `0f103ff` — drop unused `from .main import create_app` re-export in `backend/src/api/__init__.py`. The eager re-export created a circular import path under uvicorn (`api/__init__.py` → `api/main.py` → `agent_mcp/server.py` → `from api.deps` → re-runs `api/__init__.py`). CI's pytest didn't hit it because `TestClient` imports `api.main:create_app` directly. Caught when `docker compose up backend` failed to start.

## Test plan

- [x] `cargo test --workspace --lib` — 78/78 pass
- [x] `docker compose up -d` — backend container reaches healthy, `/health/live` returns 200
- [x] kind multi-node verification (see K8s addendum)
