### PR TITLE
chore: sync 0.2.0 version bump back to develop

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chain-analysis"
-version = "0.1.0"
+version = "0.2.0"
 description = "Blockchain transaction analysis platform for detecting and investigating money laundering patterns"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/etl-rs/Cargo.lock
+++ b/etl-rs/Cargo.lock
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "clickhouse-process-bin"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "color-eyre",
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "etl"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "clickhouse",
@@ -1512,7 +1512,7 @@ dependencies = [
 
 [[package]]
 name = "ingest-bin"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "color-eyre",
@@ -4245,7 +4245,7 @@ dependencies = [
 
 [[package]]
 name = "worker-bin"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "color-eyre",
  "etl",

--- a/etl-rs/crates/bin/clickhouse-process/Cargo.toml
+++ b/etl-rs/crates/bin/clickhouse-process/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickhouse-process-bin"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [[bin]]

--- a/etl-rs/crates/bin/ingest/Cargo.toml
+++ b/etl-rs/crates/bin/ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ingest-bin"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [[bin]]

--- a/etl-rs/crates/bin/worker/Cargo.toml
+++ b/etl-rs/crates/bin/worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "worker-bin"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [[bin]]

--- a/etl-rs/crates/etl/Cargo.toml
+++ b/etl-rs/crates/etl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etl"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [lib]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chain-analysis-frontend",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0",


### PR DESCRIPTION
Merges the 0.2.0 version bump from the release branch back into develop so develop and main don't drift on version numbers.
